### PR TITLE
[installer][target] setup extraction progress. Some refactoring ... need...

### DIFF
--- a/installer/target/qt_target/qt_target_installer/extractworker.cpp
+++ b/installer/target/qt_target/qt_target_installer/extractworker.cpp
@@ -1,0 +1,44 @@
+#include <QDebug>
+#include <QTextStream>
+#include "extractworker.h"
+
+QProcess *myProcess = NULL;
+
+ExtractWorker::ExtractWorker(QString sourcename, QString targetname)
+{
+    this->sourceName = QString(sourcename);
+    this->destName = QString(targetname);
+
+}
+
+void ExtractWorker::process()
+{
+    myProcess = new QProcess();
+    connect(myProcess, SIGNAL(readyRead()), this, SLOT(readFromProcess()));
+    myProcess->setProcessChannelMode(QProcess::MergedChannels);
+    myProcess->start("/bin/sh -c \"pv -n " + sourceName + " | tar xJf - -C " + destName);
+
+    myProcess->waitForFinished(-1);
+    qDebug() << "exitCodePv: " << myProcess->exitCode();
+    qDebug() << myProcess->readAllStandardError();
+    qDebug() << myProcess->readAllStandardOutput();
+
+    emit finished();
+}
+
+void ExtractWorker::readFromProcess()
+{
+    QString value = myProcess->readAll();
+    qDebug() << "signal to read value";
+    qDebug() << "readAll: " << value;
+    qDebug() << "assuming intvalue: " << value.toInt();
+    qDebug() << "assuming longvalue: " << value.toLong();
+    qDebug() << "standartOut: " << myProcess->readAllStandardOutput();
+    if (myProcess->readAllStandardError().size() > 0)
+    {
+        emit error();
+        return;
+    }
+
+    emit progressUpdate(value.toInt());
+}

--- a/installer/target/qt_target/qt_target_installer/extractworker.h
+++ b/installer/target/qt_target/qt_target_installer/extractworker.h
@@ -1,0 +1,27 @@
+#include <QObject>
+#include <QString>
+#include <QProcess>
+
+#ifndef EXTRACTWORKER_H
+#define EXTRACTWORKER_H
+
+class ExtractWorker : public QObject {
+    Q_OBJECT
+
+    QString sourceName;
+    QString destName;
+
+public:
+    ExtractWorker(QString source, QString dest);
+
+public slots:
+    void process();
+    void readFromProcess();
+
+signals:
+    void finished();
+    void progressUpdate(unsigned);
+    void error();
+};
+
+#endif // EXTRACTWORKER_H

--- a/installer/target/qt_target/qt_target_installer/main.cpp
+++ b/installer/target/qt_target/qt_target_installer/main.cpp
@@ -1,6 +1,7 @@
 #include <QApplication>
 #include "mainwindow.h"
 #include <QFontDatabase>
+#include <QTimer>
 
 int main(int argc, char *argv[])
 {
@@ -9,6 +10,8 @@ int main(int argc, char *argv[])
     fontDatabase.addApplicationFont(":/assets/resources/SourceSansPro-Regular.ttf");
     MainWindow w;
     w.show();
-    w.install();
+
+    // make sure our app installs only after starting the event loop
+    QTimer::singleShot(0, &w, SLOT(install()));
     return a.exec();
 }

--- a/installer/target/qt_target/qt_target_installer/mainwindow.h
+++ b/installer/target/qt_target/qt_target_installer/mainwindow.h
@@ -5,6 +5,7 @@
 #include "logger.h"
 #include "utils.h"
 #include <QString>
+#include <QProcess>
 
 namespace Ui {
 class MainWindow;
@@ -17,12 +18,17 @@ class MainWindow : public QMainWindow
 public:
     explicit MainWindow(QWidget *parent = 0);
     ~MainWindow();
+
+public slots:
     void install();
+    void setProgress(unsigned value);
+    void finished();
 
 private:
     Ui::MainWindow *ui;
     Logger *logger;
     QString dev;
     void haltInstall(QString errorMsg);
+    void preseed();
 };
 #endif

--- a/installer/target/qt_target/qt_target_installer/qt_target_installer.pro
+++ b/installer/target/qt_target/qt_target_installer/qt_target_installer.pro
@@ -15,13 +15,15 @@ SOURCES += main.cpp\
         mainwindow.cpp \
     utils.cpp \
     logger.cpp \
-    cmdlineparser.cpp
+    cmdlineparser.cpp \
+    extractworker.cpp
 
 HEADERS  += mainwindow.h \
     utils.h \
     logger.h \
     cmdlineparser.h \
-    filesystem.h
+    filesystem.h \
+    extractworker.h
 
 FORMS    += mainwindow.ui
 


### PR DESCRIPTION
...s cleanup! Needs proper coding for failures etc

NOTE: My code looks ugly at this state and there's no error handling at the moment...I had enough stress with QProcess and Pipes and connecting to readyRead and basic noobishness ... grrrr....

Ok, thread is necessary to get proper gui updates on extraction. Therefor the code needed further refactoring so we trigger the right steps only when we finished extraction  (modularizing, at least in methods is way more readable by the way).

At least I think my approach is the only sane quick-shot solution we can get with QT4.8. 
Check it out.
I've used an extra tar.xz for my local tests.
Created using dd if=/dev/zero of=dummy bs=1g count=2 && tar cJf dummy.tar.xz dummy
(you may need bs=1G) this creates a wonderful 2G file which gives some action...have fun!
