### PR TITLE
[package] [mediacenter-osmc] Disable framebuffer screensaver before star...

### DIFF
--- a/package/mediacenter-osmc/files/DEBIAN/control
+++ b/package/mediacenter-osmc/files/DEBIAN/control
@@ -1,5 +1,5 @@
 Origin: OSMC
-Version: 13.9.993
+Version: 13.9.994
 Section: multimedia
 Essential: No
 Priority: optional

--- a/package/mediacenter-osmc/patches/rbp-watchdog
+++ b/package/mediacenter-osmc/patches/rbp-watchdog
@@ -17,6 +17,9 @@ if [ "$1" == "stop" ]; then
         exit
 fi
 
+sudo chmod a+rw /dev/tty1
+sudo /usr/bin/setterm --blank 0 </dev/tty1 >/dev/tty1
+
 if [ ! -e /tmp/fb_resolution ]; then
         /bin/fbset | grep geometry | awk '{print "-xres "$2" -yres "$3" -vxres "$4" -vyres "$5}' | sudo tee /tmp/fb_resolution >/dev/null
 fi


### PR DESCRIPTION
...ting Kodi. Fixes issue where fb screensaver is blanked when exiting kodi and sometimes won't unblank to show splash screen and tty1 login.
