### PR TITLE
[package] [mediacenter-osmc] Do not automatically start mediacenter pack...

### DIFF
--- a/package/mediacenter-osmc/files/DEBIAN/postinst
+++ b/package/mediacenter-osmc/files/DEBIAN/postinst
@@ -4,5 +4,3 @@ systemctl enable mediacenter.service
 
 ischroot
 if [ $? == 0 ]; then exit 0; fi
-
-systemctl start mediacenter.service


### PR DESCRIPTION
...age after package upgrade to prevent kodi launching before complete apt upgrade is finished.
