### PR TITLE
[installer] [host] Linux: Fix errors with latest distributions

### DIFF
--- a/installer/host/qt_host_installer/osmcinstaller
+++ b/installer/host/qt_host_installer/osmcinstaller
@@ -17,14 +17,17 @@ if [ $debug -eq 0 ]; then
     cd "$dir"
 fi
 
+export QT_X11_NO_MITSHM=1
+cmd="$dir/qt_host_installer"
+
 if [[ $EUID -eq 0 ]]; then
-    $dir/qt_host_installer
+    $cmd
 elif command -v gksudo; then
-    gksu -k $dir/qt_host_installer
+    gksu -k $cmd
 elif command -v kdesu; then
-    kdesu QT_X11_NO_MITSHM=1 $dir/qt_host_installer
+    kdesu $cmd
 elif command -v xdg-su; then
-    xdg-su -c $dir/qt_host_installer
+    xdg-su -c $cmd
 else
-    sudo QT_X11_NO_MITSHM=1 $dir/qt_host_installer
+    sudo $cmd
 fi


### PR DESCRIPTION
As discussed here[1], setting QT_X11_NO_MITSHM=1 fixes issues at least in Debian
testing and, as Sam said, should not hurt others.

I have tested this patch and it works on Debian testing.

[1]: https://discourse.osmc.tv/t/osmcinstaller-does-not-work-on-debian-testing/10163/9

Signed-off-by: Rodrigo Campos <rodrigo@sdfg.com.ar>