### PR TITLE
[package] [mediacenter-addon-osmc] Try to fix unicode errors in log messages

### DIFF
--- a/package/mediacenter-addon-osmc/src/script.module.osmcsetting.updates/resources/lib/update_service.py
+++ b/package/mediacenter-addon-osmc/src/script.module.osmcsetting.updates/resources/lib/update_service.py
@@ -38,7 +38,7 @@ def lang(id):
 
 
 def log(message, label = ''):
-	logmsg       = '%s : %s - %s ' % (__addonid__ , str(label), str(message.encode( 'utf-8', 'ignore' )))
+	logmsg       = u'%s : %s - %s ' % (__addonid__ , label, message.encode( 'utf-8', 'ignore' ))
 	xbmc.log(msg = logmsg, level=xbmc.LOGDEBUG)
 
 @clog(log)


### PR DESCRIPTION
string format already handles the string conversion

https://gist.github.com/fernandog/dc3e641b66d741e9179c

 http://paste.osmc.io/wazatudoni

@karnage @samnazarko 