### PR TITLE
[installer] [host] Fix bad changelod date

### DIFF
--- a/installer/host/osmc-installer.spec
+++ b/installer/host/osmc-installer.spec
@@ -175,5 +175,5 @@ rm -rf $RPM_BUILD_ROOT
 
 
 %changelog
-* Mon Oct 12 2014 Sam G. Nazarko
+* Sun Oct 12 2014 Sam G. Nazarko
 - OBS initial release, thanks to Ivan Gonzalez (malkavi) for help


### PR DESCRIPTION
Change day of the week to the correct one. OBS can't build without the correct date.