### PR TITLE
Fix options background rendering

### DIFF
--- a/package/mediacenter-skin-osmc/files/usr/share/kodi/addons/skin.osmc/16x9/Includes.xml
+++ b/package/mediacenter-skin-osmc/files/usr/share/kodi/addons/skin.osmc/16x9/Includes.xml
@@ -67,7 +67,7 @@
 	<include name="OptionsBackgroundImage">
 		<control type="image">
 			<include>FullscreenDimensions</include>
-			<texture border="20">dialogs/DialogBackground_2.png</texture>
+			<texture border="20">dialogs/OptionsBackground.png</texture>
 		</control>
 	</include>
 	<!-- Fanart -->


### PR DESCRIPTION
When opening the sidebar options (e.g., EPG Guide) the option text would overlap the window text making it impossible to read. Includes.xml appears to attempt to link a file not present causing Kodi to render no background whatsoever. Corrected name of PNG file so it correctly renders.