### PR TITLE
AppleWhite Remote: KEY_MENU-> KEY_ESC

### DIFF
--- a/package/remote-osmc/files/etc/lirc/apple-white-A1156-lircd.conf
+++ b/package/remote-osmc/files/etc/lirc/apple-white-A1156-lircd.conf
@@ -14,32 +14,32 @@
 
 begin remote
 
-  name  Apple_A1156
-  bits            8
-  flags SPACE_ENC|CONST_LENGTH
-  eps            30
-  aeps          100
+  name							Apple_A1156
+  bits							8
+  flags							SPACE_ENC|CONST_LENGTH
+  eps							30
+  aeps							100
 
-  header       9140  4510
-  one           633  1666
-  zero          633   537
-  ptrail        631
-  repeat       9137  2220
-  pre_data_bits   16
-  pre_data       0x77E1
-  post_data_bits  8
-  post_data      0x2C
-  gap          108756
-  toggle_bit_mask 0x0
-  ignore_mask 0x80ff
+  header						9140	4510
+  one							633		1666
+  zero							633		537
+  ptrail						631
+  repeat						9137	2220
+  pre_data_bits					16
+  pre_data						0x77E1
+  post_data_bits				8
+  post_data						0x2C
+  gap							108756
+  toggle_bit_mask				0x0
+  ignore_mask					0x80ff
 
       begin codes
-          KEY_UP                   0x50
-          KEY_DOWN                 0x30
-          KEY_LEFT                 0x90
-          KEY_RIGHT                0x60
-          KEY_OK                   0xA0
-          KEY_MENU                 0xC0
+          KEY_UP				0x50
+          KEY_DOWN				0x30
+          KEY_LEFT				0x90
+          KEY_RIGHT				0x60
+          KEY_OK				0xA0
+          KEY_ESC				0xC0
       end codes
 
 end remote


### PR DESCRIPTION
Modifying Apple Remote to work as before the Jarvis Update.