### PR TITLE
Don't throw an error updating on Feb 29

### DIFF
--- a/package/mediacenter-addon-osmc/src/script.module.osmcsetting.updates/resources/lib/simple_scheduler.py
+++ b/package/mediacenter-addon-osmc/src/script.module.osmcsetting.updates/resources/lib/simple_scheduler.py
@@ -13,7 +13,7 @@ class SimpleScheduler(object):
 		self.daynum 		= setting_dict.get('check_day', 1)				# the days from month end that the action should occur [-16, 16]
 		self.hour 			= setting_dict.get('check_hour', 3)				# the hour the action should occur (integer)
 		self.minute 		= setting_dict.get('check_minute', 0)			# the minute the action should occur (integer)
-		self.trigger_time 	= datetime.datetime.now().replace(year=2222)	# the time of the next update check
+		self.trigger_time 	= datetime.datetime.now().replace(year=2224)	# the time of the next update check
 		self.leeway			= 15											# the number of minutes past the action time that the action can still take place
 
 		if right_now is None:


### PR DESCRIPTION
Initial date setting in the simple scheduler fails on Feb 29 because
it doesn't use a leap year. Feb 29 is only valid on leap years so use
one to stop a datetime exception and subsequent user error message about
a failed update.