### PR TITLE
Fix OSMC walkthru hanging if no network detected

### DIFF
--- a/installer/noobs/os-pi1.json
+++ b/installer/noobs/os-pi1.json
@@ -8,5 +8,6 @@
 	"username": "osmc",
 	"password": "osmc",
 	"supported_hex_revisions": "2,3,4,5,6,7,8,9,d,e,f,10,11,12,14,19,900092",
-	"feature_level": 35120124
+	"feature_level": 35120124,
+	"supported_models": ["Pi Model","Pi Zero"]
 }

--- a/installer/noobs/os-pi2.json
+++ b/installer/noobs/os-pi2.json
@@ -8,5 +8,6 @@
 	"username": "osmc",
 	"password": "osmc",
 	"supported_hex_revisions": "1040,1041",
-	"feature_level": 0
+	"feature_level": 0,
+	"supported_models": ["Pi 2","Pi 3"]
 }

--- a/package/mediacenter-addon-osmc/src/service.osmc.settings/resources/lib/osmc_walkthru.py
+++ b/package/mediacenter-addon-osmc/src/service.osmc.settings/resources/lib/osmc_walkthru.py
@@ -487,7 +487,7 @@ class walkthru_gui(xbmcgui.WindowXMLDialog):
 		self.close()
 
 
-	def still_checking_for_network(self, controlID):
+	def still_checking_for_network(self):
 		''' Checks to see if the internet checker has finished, and if not, shows a progress bar until complete or exit. 
 			The internet checker will toggle the internet_connected bool if a connection is made.'''
 
@@ -818,7 +818,7 @@ class walkthru_gui(xbmcgui.WindowXMLDialog):
 				# if the internet is NOT connected, and the networking panel has NOT been revealed then show the internet checker progress bar. 
 				# Once that is complete (or cancelled) then check for the internet connection again
 				# and show the networking panel if negative, or jump to the next panel if positive.
-				self.still_checking_for_network(self, next_panel)
+				self.still_checking_for_network()
 
 				if self.internet_connected:
 					next_panel = self.panel_order[self.panel_order.index('networking') + 1]


### PR DESCRIPTION
OSMC Waltkthru would hang when clicking 'continue' on the license accept panel if there was no network.

This was due to originally the function call missing the controlID argument.
The quick fix for this was also causing an error due to passing 2x arguments ('self' which is not needed in Python). 

The still_checking_for_network function doesn't actually use the controlID argument, so this PR reverts the function call back to original and removes the argument from the function. There are no other calls to this function so no "breakages" elsewhere.