### PR TITLE
[package][mediacenter-skin-osmc] Added 3D flag option

### DIFF
--- a/package/mediacenter-skin-osmc/files/usr/share/kodi/addons/skin.osmc/16x9/SkinSettings.xml
+++ b/package/mediacenter-skin-osmc/files/usr/share/kodi/addons/skin.osmc/16x9/SkinSettings.xml
@@ -148,6 +148,16 @@
 					<selected>Skin.HasSetting(KioskMode)</selected>
 					<visible>ControlGroup(9).HasFocus(12)</visible>
 				</control>
+				<!-- Show 3D Info -->
+				<control type="radiobutton" id="1306">
+					<width>1120</width>
+					<height>65</height>
+					<textwidth>1120</textwidth>
+					<label>31068</label>
+					<onclick>Skin.ToggleSetting(StereoInfo)</onclick>
+					<selected>Skin.HasSetting(StereoInfo)</selected>
+					<visible>ControlGroup(9).HasFocus(12)</visible>
+				</control>
 				<!-- Reset skin's setting -->
 				<control type="button" id="1305">
 					<width>1120</width>

--- a/package/mediacenter-skin-osmc/files/usr/share/kodi/addons/skin.osmc/16x9/Viewtype50.xml
+++ b/package/mediacenter-skin-osmc/files/usr/share/kodi/addons/skin.osmc/16x9/Viewtype50.xml
@@ -49,6 +49,14 @@
 					<width>130</width>
 					<height>56</height>
 					<texture>$VAR[typehackflagging,flagging/video/,.png]</texture>
+					<visible>!(Skin.HasSetting(StereoInfo) + ListItem.IsStereoscopic)</visible>
+				</control>
+				<control type="image">
+					<left>270</left>
+					<width>130</width>
+					<height>56</height>
+					<texture>flagging/video/3D.png</texture>
+					<visible>Skin.HasSetting(StereoInfo) + ListItem.IsStereoscopic</visible>
 				</control>
 				<control type="image">
 					<top>61</top>

--- a/package/mediacenter-skin-osmc/files/usr/share/kodi/addons/skin.osmc/16x9/Viewtype51.xml
+++ b/package/mediacenter-skin-osmc/files/usr/share/kodi/addons/skin.osmc/16x9/Viewtype51.xml
@@ -178,7 +178,13 @@
 						<width>130</width>
 						<height>56</height>
 						<texture>$VAR[typehackflagging,flagging/video/,.png]</texture>
-						<visible>!IsEmpty(Control.GetLabel(777))</visible>
+						<visible>!IsEmpty(Control.GetLabel(777)) + !(Skin.HasSetting(StereoInfo) + ListItem.IsStereoscopic)</visible>
+					</control>
+					<control type="image">
+						<width>130</width>
+						<height>56</height>
+						<texture>flagging/video/3D.png</texture>
+						<visible>Skin.HasSetting(StereoInfo) + ListItem.IsStereoscopic</visible>
 					</control>
 					<control type="image">
 						<width>130</width>

--- a/package/mediacenter-skin-osmc/files/usr/share/kodi/addons/skin.osmc/16x9/Viewtype52.xml
+++ b/package/mediacenter-skin-osmc/files/usr/share/kodi/addons/skin.osmc/16x9/Viewtype52.xml
@@ -178,7 +178,13 @@
 						<width>130</width>
 						<height>56</height>
 						<texture>$VAR[typehackflagging,flagging/video/,.png]</texture>
-						<visible>!IsEmpty(Control.GetLabel(777))</visible>
+						<visible>!IsEmpty(Control.GetLabel(777)) + !(Skin.HasSetting(StereoInfo) + ListItem.IsStereoscopic)</visible>
+					</control>
+					<control type="image">
+						<width>130</width>
+						<height>56</height>
+						<texture>flagging/video/3D.png</texture>
+						<visible>Skin.HasSetting(StereoInfo) + ListItem.IsStereoscopic</visible>
 					</control>
 					<control type="image">
 						<width>130</width>

--- a/package/mediacenter-skin-osmc/files/usr/share/kodi/addons/skin.osmc/16x9/Viewtype53.xml
+++ b/package/mediacenter-skin-osmc/files/usr/share/kodi/addons/skin.osmc/16x9/Viewtype53.xml
@@ -183,7 +183,13 @@
 						<width>130</width>
 						<height>56</height>
 						<texture>$VAR[typehackflagging,flagging/video/,.png]</texture>
-						<visible>!IsEmpty(Control.GetLabel(777))</visible>
+						<visible>!IsEmpty(Control.GetLabel(777)) + !(Skin.HasSetting(StereoInfo) + ListItem.IsStereoscopic)</visible>
+					</control>
+					<control type="image">
+						<width>130</width>
+						<height>56</height>
+						<texture>flagging/video/3D.png</texture>
+						<visible>Skin.HasSetting(StereoInfo) + ListItem.IsStereoscopic</visible>
 					</control>
 					<control type="image">
 						<width>130</width>

--- a/package/mediacenter-skin-osmc/files/usr/share/kodi/addons/skin.osmc/language/English/strings.po
+++ b/package/mediacenter-skin-osmc/files/usr/share/kodi/addons/skin.osmc/language/English/strings.po
@@ -249,3 +249,7 @@ msgstr ""
 msgctxt "#31067"
 msgid "My OSMC"
 msgstr ""
+
+msgctxt "#31068"
+msgid "Show movie 3D flag"
+msgstr ""


### PR DESCRIPTION
Allowed users to show the movie 3D flags.

Because the flag control group is designed to only show 6 items, especially in the `list` view, this replaces the media type flag.