### PR TITLE
[package] [libsqlite-osmc] Fix to avoid potentially over sleeping

### DIFF
--- a/package/libsqlite-osmc/build.sh
+++ b/package/libsqlite-osmc/build.sh
@@ -32,7 +32,7 @@ then
 	install_patch "../../patches" "all"
 	./configure --prefix=/usr/osmc --enable-threadsafe --disable-readline
 	export CXXFLAGS+="-DSQLITE_ENABLE_COLUMN_METADATA=1"
-	export CFLAGS+="-DSQLITE_TEMP_STORE=3 -DSQLITE_DEFAULT_MMAP_SIZE=0x10000000"
+	export CFLAGS+="-DSQLITE_TEMP_STORE=3 -DSQLITE_DEFAULT_MMAP_SIZE=0x10000000 -DHAVE_USLEEP=1"
 	export TCLLIBDIR="/dev/null"
 	$BUILD
 	make install DESTDIR=${out}

--- a/package/libsqlite-osmc/files/DEBIAN/control
+++ b/package/libsqlite-osmc/files/DEBIAN/control
@@ -1,5 +1,5 @@
 Origin: OSMC
-Version: 3.9.2.0-2
+Version: 3.9.2.0-3
 Section: libs
 Essential: No
 Priority: optional


### PR DESCRIPTION
Fix to avoid potentially sleeping for 1 second when <1 second required

Add -DHAVE_USLEEP=1 to compile-time options