### PR TITLE
[package] [bluez-osmc] Bump version

### DIFF
--- a/package/bluez-osmc/build.sh
+++ b/package/bluez-osmc/build.sh
@@ -12,7 +12,7 @@ then
     exit 0
 fi
 
-VERSION="5.38"
+VERSION="5.39"
 pull_source "https://www.kernel.org/pub/linux/bluetooth/bluez-${VERSION}.tar.xz" "$(pwd)/src"
 if [ $? != 0 ]; then echo -e "Error fetching connman source" && exit 1; fi
 # Build in native environment

--- a/package/bluez-osmc/files/DEBIAN/control
+++ b/package/bluez-osmc/files/DEBIAN/control
@@ -1,5 +1,5 @@
 Origin: OSMC
-Version: 5.3.8-8
+Version: 5.3.9
 Section: utils
 Essential: No
 Priority: optional


### PR DESCRIPTION
This bumps the version of Bluez to 5.39. This was a bugfix release that
seems to have fixed the following issues:

* Bluetooth would not be enabled on boot
* Connections would be dropped from peripherals

Tested on Rpi3.