### PR TITLE
master

### DIFF
--- a/package/mediacenter-addon-osmc/src/script.module.osmcsetting.updates/resources/lib/fstab_compare/__init__.py
+++ b/package/mediacenter-addon-osmc/src/script.module.osmcsetting.updates/resources/lib/fstab_compare/__init__.py
@@ -1,0 +1,76 @@
+# 2016-05-10 Brian Millham bmillham@gmail.com
+
+import re
+from collections import namedtuple
+
+# RE to parse fstab fields
+fields_re = re.compile(r'(?P<fs_spec>\S+)\s+(?P<fs_file>\S+)\s+'
+                       r'(?P<fs_vfstype>\S+)\s+(?P<fs_mntops>\S+)\s*'
+                       r'(?P<fs_freq>\d*)\s*(?P<fs_passno>\d*)')
+
+# Namedtuple to save each line in
+FSTabLine = namedtuple('FSTabLine',
+                       'fs_spec fs_file fs_vfstype fs_mntops fs_freq '
+                       'fs_passno spec_type mnt_dev unparsed is_comment is_empty is_bad')
+
+# Empty dict to match the namedtuple
+fstab_line_empty = {'fs_spec': None, 'fs_file': None, 'fs_vfstype': None, 'fs_mntops': None,
+                    'fs_freq': '', 'fs_passno': '', 'spec_type': None, 'mnt_dev': None,
+                    'unparsed': None, 'is_comment': False, 'is_empty': False, 'is_bad': False}
+
+class fstab_compare(object):
+    """ A class to make finding lines in a backedup fstab easy to find """
+    def __init__(self, current_fstab, backup_fstab):
+        """ Call with the current fstab, and the backup fstab """
+        self.current_lines = self.__readfstab(current_fstab)
+        self.backup_lines = self.__readfstab(backup_fstab)
+        self.original_fs_files = [o.fs_file for o in self.current_lines if o.fs_file is not None]
+
+    def __readfstab(self, file):
+        """ Internal. Used to read the fstab file into the namedtuple """
+        lines = []
+        with open(file) as fstab_file:
+            for line in fstab_file:
+                lines.append(self.__namedtuple(line))
+        return lines
+
+    def __namedtuple(self, line):
+        """ Internal. Convert a fstab line into a namedtuple """
+        lines = []
+        line = line.rstrip() # Remove trailing newlines
+        d = fstab_line_empty.copy()
+        if line == '':
+            d['is_empty'] = True
+        if not line.startswith('#'):
+            try:
+                d.update([m.groupdict() for m in fields_re.finditer(line)][0])
+            except:
+                d['is_bad'] = True
+            try:
+                d['spec_type'], d['mnt_dev'] = d['fs_spec'].split("=")
+            except:
+                pass
+            # Sort fs_mntops so the order does not matter between the files
+            if d['fs_mntops'] is not None:
+                d['fs_mntops'] = ",".join(sorted(d['fs_mntops'].split(',')))
+        else:
+            d['is_comment'] = True
+            d['unparsed'] = line
+        return FSTabLine(**d)
+
+    def __diffs(self):
+        """ Internal. Create a list of lines in the backup fstab not found
+            in the current fstab """
+        return list(set(self.backup_lines) - set(self.current_lines))
+
+    def formatted(self, line):
+        """ Return a properly formatted fstab line """
+        return "{.fs_spec} {.fs_file} {.fs_vfstype} {.fs_mntops} {.fs_freq} {.fs_passno}".format(line, line, line, line, line, line)
+
+    def unique_fs_files(self):
+        """ Return a list of the backed up fstab namedtuples (not in current fstab) """
+        return [d for d in self.__diffs() if d.fs_file not in self.original_fs_files and d.fs_file is not None]
+
+    def unique_fs_files_formatted(self):
+        """ Return formatted lines of the backed up fstab lines (not in current fstab) """
+        return [self.formatted(d) for d in self.unique_fs_files()]

--- a/package/mediacenter-addon-osmc/src/script.module.osmcsetting.updates/resources/lib/fstab_restore.py
+++ b/package/mediacenter-addon-osmc/src/script.module.osmcsetting.updates/resources/lib/fstab_restore.py
@@ -1,0 +1,16 @@
+#!/usr/bin/python
+
+# Script to show how the fstab_compare module can be used
+# 2016-05-10 Brian Millham bmillham@gmail.com
+
+from fstab_compare import fstab_compare
+
+fstab = '/etc/fstab'
+fstab_backup = "fstab.backup"
+
+fstab_diffs = fstab_compare(fstab, fstab_backup)
+
+print "Lines in backup that are not in new fstab, skipping lines that would override a fs_file"
+
+for l in fstab_diffs.unique_fs_files_formatted():
+    print l


### PR DESCRIPTION
commit cd47bdd6d473864bfc6f209fd6d40f01e0f79eba
Reflog: HEAD@{0} (Brian Millham <brian@millham.net>)
Reflog message: commit: Added new python module to show lines in a backup fstab that are not in the current fstab. Includes a short script as an example of how the module works.
Author: Brian Millham <brian@millham.net>
Date:   Tue May 10 20:47:59 2016 -0400

    Added new python module to show lines in a backup fstab that are not in the current fstab. Includes a short script as an example of how the module works.

commit 331140dc4a7a414ff30c0ff73bc13f4b04fee0c2
Reflog: HEAD@{1} (Brian Millham <brian@millham.net>)
Reflog message: clone: from git@github.com:bmillham/osmc.git
Author: Sam Nazarko <email@samnazarko.co.uk>
Date:   Wed May 4 18:19:31 2016 +0100

    [package] [kernel-osmc] RBP: bump version
    
    Signed-off-by: Sam Nazarko <email@samnazarko.co.uk>