### PR TITLE
[package][eventlircd-osmc] Fix wminput device udev name

### DIFF
--- a/package/eventlircd-osmc/files/lib/udev/rules.d/98-eventlircd.rules
+++ b/package/eventlircd-osmc/files/lib/udev/rules.d/98-eventlircd.rules
@@ -57,7 +57,7 @@ ATTRS{name}=="bdremoteng", \
 # value for "eventlircd_evmap" For more information on wminput, see
 # <http://abstrakraft.org/cwiid/>.
 #-------------------------------------------------------------------------------
-ATTRS{name}=="bdremoteng", \
+ATTRS{name}=="Nintendo Wiimote", \
   ENV{eventlircd_enable}="true"
 
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
Fix udev "name" attribute for devices created by CWiid / wminput