### PR TITLE
[package] [mediacenter-osmc] Allow Volume actions without waking up s…

### DIFF
--- a/package/mediacenter-osmc/patches/all-066-Allow-volume-actions-without-waking-up-screensaver.patch
+++ b/package/mediacenter-osmc/patches/all-066-Allow-volume-actions-without-waking-up-screensaver.patch
@@ -1,0 +1,37 @@
+From 9095a8bc4f2c67fba1064d7c567b636d1ed3ce7a Mon Sep 17 00:00:00 2001
+From: Jeffrey Larson <jeffothy@gmail.com>
+Date: Mon, 8 Aug 2016 18:15:30 +0000
+Subject: [PATCH 1/1] Allow volume actions without waking up screensaver
+
+---
+ xbmc/input/InputManager.cpp | 7 +++++--
+ 1 file changed, 5 insertions(+), 2 deletions(-)
+
+diff --git a/xbmc/input/InputManager.cpp b/xbmc/input/InputManager.cpp
+index 1e21e7b..85a7615 100644
+--- a/xbmc/input/InputManager.cpp
++++ b/xbmc/input/InputManager.cpp
+@@ -589,7 +589,7 @@ bool CInputManager::OnKey(const CKey& key)
+   g_application.ResetScreenSaver();
+ 
+   // allow some keys to be processed while the screensaver is active
+-  if (g_application.WakeUpScreenSaverAndDPMS(processKey) && !processKey)
++  if (!processKey && g_application.WakeUpScreenSaverAndDPMS(processKey))
+   {
+     CLog::LogF(LOGDEBUG, "%s pressed, screen saver/dpms woken up", m_Keyboard.GetKeyName((int)key.GetButtonCode()).c_str());
+     return true;
+@@ -713,7 +713,10 @@ bool CInputManager::AlwaysProcess(const CAction& action)
+         || builtInFunction == "suspend"
+         || builtInFunction == "hibernate"
+         || builtInFunction == "quit"
+-        || builtInFunction == "shutdown")
++        || builtInFunction == "shutdown"
++        || builtInFunction == "volumeup"
++        || builtInFunction == "volumedown"
++        || builtInFunction == "mute")
+     {
+       return true;
+     }
+-- 
+2.1.4
+


### PR DESCRIPTION
…creensaver

Add VolumeUp, VolumeDown and Mute to builtInFunctions list that are
ignored by Screensaver wake up.