### PR TITLE
[package] [libcec-osmc] Add patch to backport AVR auto wake changes

### DIFF
--- a/package/libcec-osmc/patches/all-005-config-option-power-up-avr.patch
+++ b/package/libcec-osmc/patches/all-005-config-option-power-up-avr.patch
@@ -1,0 +1,64 @@
+diff -Naur a/include/cectypes.h b/include/cectypes.h
+--- a/include/cectypes.h	2016-10-30 15:36:30.593740078 +0000
++++ b/include/cectypes.h	2016-10-30 15:44:24.893006860 +0000
+@@ -1495,7 +1495,7 @@
+   uint32_t              iComboKeyTimeoutMs;   /*!< timeout until the combo key is sent as normal keypress */
+   uint32_t              iButtonRepeatRateMs;  /*!< rate at which buttons autorepeat. 0 means rely on CEC device */
+   uint32_t              iButtonReleaseDelayMs;/*!< duration after last update until a button is considered released */
+-
++ uint8_t               bAutoWakeAVR;         /*!< set to 1 to automatically waking an AVR when the source is activated. */
+ #ifdef __cplusplus
+    libcec_configuration(void) { Clear(); }
+   ~libcec_configuration(void) { Clear(); }
+@@ -1531,6 +1531,7 @@
+                  iDoubleTapTimeout50Ms     == other.iDoubleTapTimeout50Ms &&
+                  iButtonRepeatRateMs       == other.iButtonRepeatRateMs &&
+                  iButtonReleaseDelayMs     == other.iButtonReleaseDelayMs &&
++		 bAutoWakeAVR              == other.bAutoWakeAVR &&
+                  (other.clientVersion <= LIBCEC_VERSION_TO_UINT(2, 0, 4) || comboKey            == other.comboKey) &&
+                  (other.clientVersion <= LIBCEC_VERSION_TO_UINT(2, 0, 4) || iComboKeyTimeoutMs  == other.iComboKeyTimeoutMs) &&
+                  (other.clientVersion <  LIBCEC_VERSION_TO_UINT(2, 1, 0) || bPowerOnScreensaver == other.bPowerOnScreensaver));
+@@ -1573,7 +1574,7 @@
+     iComboKeyTimeoutMs =              CEC_DEFAULT_COMBO_TIMEOUT_MS;
+     iButtonRepeatRateMs =             0;
+     iButtonReleaseDelayMs =           CEC_BUTTON_TIMEOUT;
+-
++    bAutoWakeAVR =                    0;
+     memset(strDeviceName, 0, 13);
+     deviceTypes.Clear();
+     logicalAddresses.Clear();
+diff -Naur a/src/libcec/CECClient.cpp b/src/libcec/CECClient.cpp
+--- a/src/libcec/CECClient.cpp	2016-10-30 14:13:18.401154326 +0000
++++ b/src/libcec/CECClient.cpp	2016-10-30 14:34:02.729468113 +0000
+@@ -851,7 +851,7 @@
+   configuration.iDoubleTapTimeout50Ms     = m_configuration.iDoubleTapTimeout50Ms;
+   configuration.iButtonRepeatRateMs       = m_configuration.iButtonRepeatRateMs;
+   configuration.iButtonReleaseDelayMs     = m_configuration.iButtonReleaseDelayMs;
+-
++  configuration.bAutoWakeAVR              = m_configuration.bAutoWakeAVR;
+   return true;
+ }
+ 
+@@ -896,7 +896,7 @@
+     m_configuration.iDoubleTapTimeout50Ms      = configuration.iDoubleTapTimeout50Ms;
+     m_configuration.iButtonRepeatRateMs        = configuration.iButtonRepeatRateMs;
+     m_configuration.iButtonReleaseDelayMs      = configuration.iButtonReleaseDelayMs;
+-
++    m_configuration.bAutoWakeAVR               = configuration.bAutoWakeAVR;
+     m_configuration.deviceTypes.Add(configuration.deviceTypes[0]);
+ 
+     if (m_configuration.clientVersion >= LIBCEC_VERSION_TO_UINT(2, 0, 5))
+diff -Naur a/src/libcec/devices/CECBusDevice.cpp b/src/libcec/devices/CECBusDevice.cpp
+--- a/src/libcec/devices/CECBusDevice.cpp	2016-10-30 14:20:39.740562756 +0000
++++ b/src/libcec/devices/CECBusDevice.cpp	2016-10-30 14:20:07.100606768 +0000
+@@ -1023,8 +1023,9 @@
+   bool bReturn(true);
+   if (iDelay == 0)
+   {
++    libcec_configuration config;
+     /** send system audio mode request if AVR exists */
+-    if (m_iLogicalAddress != CECDEVICE_AUDIOSYSTEM) 
++    if (m_iLogicalAddress != CECDEVICE_AUDIOSYSTEM && LIB_CEC->GetCurrentConfiguration(&config) && config.bAutoWakeAVR == 1) 
+     {
+       CCECBusDevice* audioSystem(m_processor->GetDevice(CECDEVICE_AUDIOSYSTEM));
+       if (audioSystem && audioSystem->IsPresent())

--- a/package/mediacenter-osmc/patches/all-070-add-configuration-option-autowake-avr.patch
+++ b/package/mediacenter-osmc/patches/all-070-add-configuration-option-autowake-avr.patch
@@ -1,0 +1,48 @@
+diff -Naur xbmc-c327c53ac5346f71219e8353fe046e43e4d4a827/addons/resource.language.en_gb/resources/strings.po xbmc-b/addons/resource.language.en_gb/resources/strings.po
+--- xbmc-c327c53ac5346f71219e8353fe046e43e4d4a827/addons/resource.language.en_gb/resources/strings.po	2016-11-06 10:05:20.364000000 +0000
++++ xbmc-b/addons/resource.language.en_gb/resources/strings.po	2016-11-07 10:09:34.396000000 +0000
+@@ -15529,6 +15529,11 @@
+ msgid "Pause Playback"
+ msgstr ""
+ 
++#: system/peripherals.xml
++msgctxt "#36046"
++msgid "Force AVR wake up when Kodi is activated"
++msgstr ""
++
+ #empty strings from id 36046 to 36100
+ #strings from 36100 to 36999 are reserved for settings descriptions
+ 
+diff -Naur xbmc-c327c53ac5346f71219e8353fe046e43e4d4a827/system/peripherals.xml xbmc-b/system/peripherals.xml
+--- xbmc-c327c53ac5346f71219e8353fe046e43e4d4a827/system/peripherals.xml        2016-11-07 12:14:19.100000000 +0000
++++ xmbc-b/system/peripherals.xml       2016-11-07 12:24:36.692000000 +0000
+@@ -25,6 +25,7 @@
+     <setting key="cec_hdmi_port" type="int" value="1" min="1" max="15" label="36015" order="13" />
+     <setting key="physical_address" type="string" label="36021" value="0" order="14" />
+     <setting key="port" type="string" value="" label="36022" order="15" />
++    <setting key="power_avr_on_as" type="bool" label="36046" value="0" order="16" />
+ 
+     <setting key="tv_vendor" type="int" value="0" configurable="0" />
+     <setting key="device_name" type="string" value="Kodi" configurable="0" />
+
+diff -Naur xbmc-c327c53ac5346f71219e8353fe046e43e4d4a827/xbmc/peripherals/devices/PeripheralCecAdapter.cpp xbmc-b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+--- xbmc-c327c53ac5346f71219e8353fe046e43e4d4a827/xbmc/peripherals/devices/PeripheralCecAdapter.cpp	2016-11-06 10:05:20.364000000 +0000
++++ xbmc-b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp	2016-11-07 10:16:06.628000000 +0000
+@@ -1389,7 +1389,7 @@
+   m_configuration.bPowerOffScreensaver = GetSettingBool("cec_standby_screensaver") ? 1 : 0;
+   m_configuration.bPowerOnScreensaver  = GetSettingBool("cec_wake_screensaver") ? 1 : 0;
+   m_configuration.bSendInactiveSource  = GetSettingBool("send_inactive_source") ? 1 : 0;
+-
++  m_configuration.bAutoWakeAVR         = GetSettingBool("power_avr_on_as") ? 1 : 0;
+   // read the mutually exclusive boolean settings
+   int iStandbyAction(GetSettingInt("standby_pc_on_tv_standby"));
+   m_configuration.bPowerOffOnStandby = iStandbyAction == 13011 ? 1 : 0;
+
+--- xbmc-c327c53ac5346f71219e8353fe046e43e4d4a827/xbmc/peripherals/devices/PeripheralCecAdapter.h    2016-11-06 10:05:20.364000000 +0000
++++ xbmc-b/xbmc/peripherals/devices/PeripheralCecAdapter.h    2016-11-07 10:16:06.628000000 +0000
+@@ -179,6 +179,7 @@
+     bool                              m_bOnPlayReceived;
+     bool                              m_bPlaybackPaused;
+     std::string                        m_strComPort;
++    bool				m_bAutoWakeAVR;
+   };


### PR DESCRIPTION
This will patch libcec to add in the changes added in libcec 4.0.0 that makes automatically waking any audiosystems a configuration option.

The default value is 0 so it will not automatically power up audiosystems, but I`m not sure how this option can be changed outside of the code.

