### PR TITLE
Hardening sshd conf

### DIFF
--- a/package/ftr-osmc/src/atv-ftr
+++ b/package/ftr-osmc/src/atv-ftr
@@ -3,7 +3,6 @@
 # (c) 2014-2015 Sam Nazarko
 # email@samnazarko.co.uk
 
-DSA_KEY="/etc/ssh/ssh_host_dsa_key"
 RSA_KEY="/etc/ssh/ssh_host_rsa_key"
 ECDSA_KEY="/etc/ssh/ssh_host_ecdsa_key"
 ED25519_KEY="/etc/ssh/ssh_host_ed25519_key"
@@ -11,7 +10,6 @@ PRESEED_FILE="/boot/preseed.cfg"
 POSTINST_FILE="/boot/postinst.sh"
 touch /tmp/NO_UPDATE
 chown osmc:osmc /tmp/NO_UPDATE
-rm -f $DSA_KEY
 rm -f $RSA_KEY
 nvidia-xconfig
 sed -e "s/console/anybody/" -i /etc/X11/Xwrapper.config
@@ -28,7 +26,6 @@ then
    bash $POSTINST_FILE &
 fi
 rm -f /etc/ssh/*_key*
-ssh-keygen -f $DSA_KEY -N '' -t dsa &
 ssh-keygen -f $RSA_KEY -N '' -t rsa &
 ssh-keygen -f $ECDSA_KEY -N '' -t ecdsa &
 ssh-keygen -f $ED25519_KEY -N '' -t ed25519 &

--- a/package/ftr-osmc/src/pc-ftr
+++ b/package/ftr-osmc/src/pc-ftr
@@ -3,7 +3,6 @@
 # (c) 2014-2015 Sam Nazarko
 # email@samnazarko.co.uk
 
-DSA_KEY="/etc/ssh/ssh_host_dsa_key"
 RSA_KEY="/etc/ssh/ssh_host_rsa_key"
 ECDSA_KEY="/etc/ssh/ssh_host_ecdsa_key"
 ED25519_KEY="/etc/ssh/ssh_host_ed25519_key"
@@ -11,7 +10,6 @@ PRESEED_FILE="/boot/preseed.cfg"
 POSTINST_FILE="/boot/postinst.sh"
 touch /tmp/NO_UPDATE
 chown osmc:osmc /tmp/NO_UPDATE
-rm -f $DSA_KEY
 rm -f $RSA_KEY
 dbus-uuidgen > /var/lib/dbus/machine-id
 depmod
@@ -26,7 +24,6 @@ then
    bash $POSTINST_FILE &
 fi
 rm -f /etc/ssh/*_key*
-ssh-keygen -f $DSA_KEY -N '' -t dsa &
 ssh-keygen -f $RSA_KEY -N '' -t rsa &
 ssh-keygen -f $ECDSA_KEY -N '' -t ecdsa &
 ssh-keygen -f $ED25519_KEY -N '' -t ed25519 &

--- a/package/ftr-osmc/src/rbp1-ftr
+++ b/package/ftr-osmc/src/rbp1-ftr
@@ -3,7 +3,6 @@
 # (c) 2014-2015 Sam Nazarko
 # email@samnazarko.co.uk
 
-DSA_KEY="/etc/ssh/ssh_host_dsa_key"
 RSA_KEY="/etc/ssh/ssh_host_rsa_key"
 ECDSA_KEY="/etc/ssh/ssh_host_ecdsa_key"
 ED25519_KEY="/etc/ssh/ssh_host_ed25519_key"
@@ -11,7 +10,6 @@ PRESEED_FILE="/boot/preseed.cfg"
 POSTINST_FILE="/boot/postinst.sh"
 touch /tmp/NO_UPDATE
 chown osmc:osmc /tmp/NO_UPDATE
-rm -f $DSA_KEY
 rm -f $RSA_KEY
 dbus-uuidgen > /var/lib/dbus/machine-id
 depmod
@@ -26,7 +24,6 @@ then
    bash $POSTINST_FILE &
 fi
 rm -f /etc/ssh/*_key*
-ssh-keygen -f $DSA_KEY -N '' -t dsa
 ssh-keygen -f $RSA_KEY -N '' -t rsa
 ssh-keygen -f $ECDSA_KEY -N '' -t ecdsa
 ssh-keygen -f $ED25519_KEY -N '' -t ed25519

--- a/package/ftr-osmc/src/rbp2-ftr
+++ b/package/ftr-osmc/src/rbp2-ftr
@@ -3,7 +3,6 @@
 # (c) 2014-2015 Sam Nazarko
 # email@samnazarko.co.uk
 
-DSA_KEY="/etc/ssh/ssh_host_dsa_key"
 RSA_KEY="/etc/ssh/ssh_host_rsa_key"
 ECDSA_KEY="/etc/ssh/ssh_host_ecdsa_key"
 ED25519_KEY="/etc/ssh/ssh_host_ed25519_key"
@@ -11,7 +10,6 @@ PRESEED_FILE="/boot/preseed.cfg"
 POSTINST_FILE="/boot/postinst.sh"
 touch /tmp/NO_UPDATE
 chown osmc:osmc /tmp/NO_UPDATE
-rm -f $DSA_KEY
 rm -f $RSA_KEY
 dbus-uuidgen > /var/lib/dbus/machine-id
 depmod
@@ -26,7 +24,6 @@ then
    bash $POSTINST_FILE &
 fi
 rm -f /etc/ssh/*_key*
-ssh-keygen -f $DSA_KEY -N '' -t dsa &
 ssh-keygen -f $RSA_KEY -N '' -t rsa &
 ssh-keygen -f $ECDSA_KEY -N '' -t ecdsa &
 ssh-keygen -f $ED25519_KEY -N '' -t ed25519 &

--- a/package/ftr-osmc/src/vero1-ftr
+++ b/package/ftr-osmc/src/vero1-ftr
@@ -3,7 +3,6 @@
 # (c) 2014-2015 Sam Nazarko
 # email@samnazarko.co.uk
 
-DSA_KEY="/etc/ssh/ssh_host_dsa_key"
 RSA_KEY="/etc/ssh/ssh_host_rsa_key"
 ECDSA_KEY="/etc/ssh/ssh_host_ecdsa_key"
 ED25519_KEY="/etc/ssh/ssh_host_ed25519_key"
@@ -11,7 +10,6 @@ PRESEED_FILE="/boot/preseed.cfg"
 POSTINST_FILE="/boot/postinst.sh"
 touch /tmp/NO_UPDATE
 chown osmc:osmc /tmp/NO_UPDATE
-rm -f $DSA_KEY
 rm -f $RSA_KEY
 dbus-uuidgen > /var/lib/dbus/machine-id
 depmod
@@ -26,7 +24,6 @@ then
    bash $POSTINST_FILE &
 fi
 rm -f /etc/ssh/*_key*
-ssh-keygen -f $DSA_KEY -N '' -t dsa &
 ssh-keygen -f $RSA_KEY -N '' -t rsa &
 ssh-keygen -f $ECDSA_KEY -N '' -t ecdsa &
 ssh-keygen -f $ED25519_KEY -N '' -t ed25519 &

--- a/package/ftr-osmc/src/vero2-ftr
+++ b/package/ftr-osmc/src/vero2-ftr
@@ -3,7 +3,6 @@
 # (c) 2014-2015 Sam Nazarko
 # email@samnazarko.co.uk
 
-DSA_KEY="/etc/ssh/ssh_host_dsa_key"
 RSA_KEY="/etc/ssh/ssh_host_rsa_key"
 ECDSA_KEY="/etc/ssh/ssh_host_ecdsa_key"
 ED25519_KEY="/etc/ssh/ssh_host_ed25519_key"
@@ -11,7 +10,6 @@ PRESEED_FILE="/boot/preseed.cfg"
 POSTINST_FILE="/boot/postinst.sh"
 touch /tmp/NO_UPDATE
 chown osmc:osmc /tmp/NO_UPDATE
-rm -f $DSA_KEY
 rm -f $RSA_KEY
 dbus-uuidgen > /var/lib/dbus/machine-id
 depmod
@@ -26,7 +24,6 @@ then
    bash $POSTINST_FILE &
 fi
 rm -f /etc/ssh/*_key*
-ssh-keygen -f $DSA_KEY -N '' -t dsa &
 ssh-keygen -f $RSA_KEY -N '' -t rsa &
 ssh-keygen -f $ECDSA_KEY -N '' -t ecdsa &
 ssh-keygen -f $ED25519_KEY -N '' -t ed25519 &

--- a/package/ftr-osmc/src/vero3-ftr
+++ b/package/ftr-osmc/src/vero3-ftr
@@ -3,7 +3,6 @@
 # (c) 2014-2015 Sam Nazarko
 # email@samnazarko.co.uk
 
-DSA_KEY="/etc/ssh/ssh_host_dsa_key"
 RSA_KEY="/etc/ssh/ssh_host_rsa_key"
 ECDSA_KEY="/etc/ssh/ssh_host_ecdsa_key"
 ED25519_KEY="/etc/ssh/ssh_host_ed25519_key"
@@ -11,7 +10,6 @@ PRESEED_FILE="/boot/preseed.cfg"
 POSTINST_FILE="/boot/postinst.sh"
 touch /tmp/NO_UPDATE
 chown osmc:osmc /tmp/NO_UPDATE
-rm -f $DSA_KEY
 rm -f $RSA_KEY
 dbus-uuidgen > /var/lib/dbus/machine-id
 depmod
@@ -26,7 +24,6 @@ then
    bash $POSTINST_FILE &
 fi
 rm -f /etc/ssh/*_key*
-ssh-keygen -f $DSA_KEY -N '' -t dsa &
 ssh-keygen -f $RSA_KEY -N '' -t rsa &
 ssh-keygen -f $ECDSA_KEY -N '' -t ecdsa &
 ssh-keygen -f $ED25519_KEY -N '' -t ed25519 &

--- a/package/ssh-app-osmc/files/etc/ssh/sshd_config
+++ b/package/ssh-app-osmc/files/etc/ssh/sshd_config
@@ -24,7 +24,7 @@ LogLevel INFO
 
 # Authentication:
 LoginGraceTime 120
-PermitRootLogin yes
+PermitRootLogin no
 StrictModes yes
 
 RSAAuthentication yes

--- a/package/ssh-app-osmc/files/etc/ssh/sshd_config
+++ b/package/ssh-app-osmc/files/etc/ssh/sshd_config
@@ -23,7 +23,9 @@ SyslogFacility AUTH
 LogLevel INFO
 
 # Authentication:
-LoginGraceTime 120
+LoginGraceTime 30
+MaxAuthTries 2
+AllowUsers osmc
 PermitRootLogin no
 StrictModes yes
 

--- a/package/ssh-app-osmc/files/etc/ssh/sshd_config
+++ b/package/ssh-app-osmc/files/etc/ssh/sshd_config
@@ -29,6 +29,9 @@ AllowUsers osmc
 PermitRootLogin no
 StrictModes yes
 
+ClientAliveInterval 300
+ClientAliveCountMax 2
+
 RSAAuthentication yes
 PubkeyAuthentication yes
 #AuthorizedKeysFile	%h/.ssh/authorized_keys

--- a/package/ssh-app-osmc/files/etc/ssh/sshd_config
+++ b/package/ssh-app-osmc/files/etc/ssh/sshd_config
@@ -9,7 +9,6 @@ Port 22
 Protocol 2
 # HostKeys for protocol version 2
 HostKey /etc/ssh/ssh_host_rsa_key
-HostKey /etc/ssh/ssh_host_dsa_key
 HostKey /etc/ssh/ssh_host_ecdsa_key
 HostKey /etc/ssh/ssh_host_ed25519_key
 #Privilege Separation is turned on for security

--- a/package/ssh-app-osmc/files/etc/ssh/sshd_config
+++ b/package/ssh-app-osmc/files/etc/ssh/sshd_config
@@ -31,6 +31,11 @@ RSAAuthentication yes
 PubkeyAuthentication yes
 #AuthorizedKeysFile	%h/.ssh/authorized_keys
 
+#Use safest ciphers and algorithms in priority
+KexAlgorithms curve25519-sha256@libssh.org,ecdh-sha2-nistp521,ecdh-sha2-nistp384,ecdh-sha2-nistp256,diffie-hellman-group-exchange-sha256
+Ciphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr
+MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,umac-128@openssh.com
+
 # Don't read the user's ~/.rhosts and ~/.shosts files
 IgnoreRhosts yes
 # For this to work you will also need host keys in /etc/ssh_known_hosts

--- a/package/ssh-app-osmc/files/etc/ssh/sshd_config
+++ b/package/ssh-app-osmc/files/etc/ssh/sshd_config
@@ -36,6 +36,8 @@ KexAlgorithms curve25519-sha256@libssh.org,ecdh-sha2-nistp521,ecdh-sha2-nistp384
 Ciphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr
 MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,umac-128@openssh.com
 
+# Disable port forwarding
+AllowTcpForwarding no
 # Don't read the user's ~/.rhosts and ~/.shosts files
 IgnoreRhosts yes
 # For this to work you will also need host keys in /etc/ssh_known_hosts

--- a/package/ssh-app-osmc/files/etc/ssh/sshd_config
+++ b/package/ssh-app-osmc/files/etc/ssh/sshd_config
@@ -12,7 +12,7 @@ HostKey /etc/ssh/ssh_host_rsa_key
 HostKey /etc/ssh/ssh_host_ecdsa_key
 HostKey /etc/ssh/ssh_host_ed25519_key
 #Privilege Separation is turned on for security
-UsePrivilegeSeparation yes
+UsePrivilegeSeparation sandbox
 
 # Lifetime and size of ephemeral version 1 server key
 KeyRegenerationInterval 3600

--- a/package/ssh-app-osmc/files/etc/ssh/sshd_config
+++ b/package/ssh-app-osmc/files/etc/ssh/sshd_config
@@ -60,7 +60,7 @@ ChallengeResponseAuthentication no
 #GSSAPIAuthentication no
 #GSSAPICleanupCredentials yes
 
-X11Forwarding yes
+X11Forwarding no
 X11DisplayOffset 10
 PrintMotd no
 PrintLastLog yes

--- a/package/ssh-app-osmc/files/etc/ssh/sshd_config
+++ b/package/ssh-app-osmc/files/etc/ssh/sshd_config
@@ -40,6 +40,8 @@ MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@op
 
 # Disable port forwarding
 AllowTcpForwarding no
+# Disable agent forwarding
+AllowAgentForwarding no
 # Don't read the user's ~/.rhosts and ~/.shosts files
 IgnoreRhosts yes
 # For this to work you will also need host keys in /etc/ssh_known_hosts


### PR DESCRIPTION
Hello,

Here are some suggestions to harden sshd default configuration, this should be compatible with ssh client as old as 5.3 (October 2009).

Some options or limits may seems a bit strict, but i took into account that OSMC box is not supposed to be a jump/bounce box (access is only via a - secure - LAN) !

I also think that users should use key authentication over password authentication, but that belongs to the wiki ;)

References
* [French Security Agency - SSH Security Guide ](https://www.ssi.gouv.fr/uploads/2014/01/NT_OpenSSH_en.pdf)
* [Mozilla - OpenSSH Security Guidelines](https://wiki.mozilla.org/Security/Guidelines/OpenSSH)
* [Samsung OSG - Improving the Security of Your SSH Configuration](https://blogs.s-osg.org/improving-the-security-of-your-ssh-server-configuration/)
* [Stribika - Secure Secure Shell](https://stribika.github.io/2015/01/04/secure-secure-shell.html)