### PR TITLE
[package] [tvheadend-app-osmc] Fix path prefix

### DIFF
--- a/package/tvheadend-app-osmc/build.sh
+++ b/package/tvheadend-app-osmc/build.sh
@@ -41,7 +41,7 @@ then
     	echo -e "TVHeadend Server\ntvheadend.service" > $APP_FILE
 	pushd src/tvheadend*
 	install_patch "../../patches" "all"
-	./configure --enable-hdhomerun_client --disable-hdhomerun_static --disable-ffmpeg_static --disable-libx264 --disable_libx264_static --disable-libx265 --disable-libx265_static --disable-libvpx --disable-libvpx_static --disable-libtheora --disable-libtheorsa_static --disable-libvorbis --disable-libvorbis_static --disable-libfdkaac --disable-libfdkaac_static --disable-nvenc --disable-libmfx_static --disable-android --enable-libsystemd_daemon --disable-kqueue --enable-dbus_1 --disable-tsdebug --disable-gtimer_check --enable-dvbscan --disable-bundle --disable-tvhcsa --enable-uriparser --disable-epoll --enable-zlib --disable-inotify --disable-dvben50221 --disable-dvbcsa --nowerror
+	./configure --prefix=/usr --enable-hdhomerun_client --disable-hdhomerun_static --disable-ffmpeg_static --disable-libx264 --disable_libx264_static --disable-libx265 --disable-libx265_static --disable-libvpx --disable-libvpx_static --disable-libtheora --disable-libtheorsa_static --disable-libvorbis --disable-libvorbis_static --disable-libfdkaac --disable-libfdkaac_static --disable-nvenc --disable-libmfx_static --disable-android --enable-libsystemd_daemon --disable-kqueue --enable-dbus_1 --disable-tsdebug --disable-gtimer_check --enable-dvbscan --disable-bundle --disable-tvhcsa --enable-uriparser --disable-epoll --enable-zlib --disable-inotify --disable-dvben50221 --disable-dvbcsa --nowerror
 	sed -e "s/0.0.0~unknown/${VERSION}~osmc/" -i support/version
 	$BUILD
 	make install DESTDIR=${out}


### PR DESCRIPTION
./configure prefix defaults to /usr/local. The systemd service expects the binary to live in /usr/bin, so it can't get started. Tested armv7-version (rpi3).
Thanks for the great work!