### PR TITLE
[package] [mediacenter-addon-osmc] Allow GPIO pins > 25 for LIRC configuration

### DIFF
--- a/package/mediacenter-addon-osmc/files/DEBIAN/control
+++ b/package/mediacenter-addon-osmc/files/DEBIAN/control
@@ -1,6 +1,6 @@
 Origin: OSMC
 Package: mediacenter-addon-osmc
-Version: 3.0.647
+Version: 3.0.648
 Section: utils
 Essential: No
 Priority: optional

--- a/package/mediacenter-addon-osmc/src/script.module.osmcsetting.pi/resources/lib/OSMC_REparser.py
+++ b/package/mediacenter-addon-osmc/src/script.module.osmcsetting.pi/resources/lib/OSMC_REparser.py
@@ -314,7 +314,7 @@ def lirc_rpi_validation(config_value):
 
 def gpio_pin_validation(config_value):
 
-	return generic_range_validation(config_value, range(1,26))
+	return generic_range_validation(config_value, range(1,28))
 
 
 def gpio_updown_validation(config_value):

--- a/package/mediacenter-addon-osmc/src/script.module.osmcsetting.pi/resources/settings.xml
+++ b/package/mediacenter-addon-osmc/src/script.module.osmcsetting.pi/resources/settings.xml
@@ -47,8 +47,8 @@
 		<!-- <setting default="false" id="allo-piano-dac-pcm512x-audio-overlay" label="32103" type="bool" visible="eq(-8, true)"/> -->
 		<setting type="lsep" label="[COLOR red]Warning[/COLOR]: GPIO remote support with default pins incompatible with HiFiBerry and iqaudio." visible="gt(-1,0)+eq(1,true)" />
 		<setting default="false" id="lirc-rpi-overlay" label="32080" type="bool"/>
-		<setting default="17" id="gpio_out_pin" label="gpio_out_pin" option="int" range="1,1,25" type="slider" visible="eq(-1,true)" subsetting="true"/>
-		<setting default="18" id="gpio_in_pin"  label="gpio_in_pin"  option="int" range="1,1,25" type="slider" visible="eq(-2,true)" subsetting="true"/>
+		<setting default="17" id="gpio_out_pin" label="gpio_out_pin" option="int" range="1,1,27" type="slider" visible="eq(-1,true)" subsetting="true"/>
+		<setting default="18" id="gpio_in_pin"  label="gpio_in_pin"  option="int" range="1,1,27" type="slider" visible="eq(-2,true)" subsetting="true"/>
 		<setting default="off" id="gpio_in_pull" label="gpio_in_pull" values="off|down|up" type="enum" visible="eq(-3,true)" subsetting="true"/>
 		<!-- <setting default="false" id="w1-gpio-overlay" label="32081" type="bool"/> -->
 		<!-- <setting default="false" id="w1-gpio-pullup-overlay" label="32082" type="bool"/> -->


### PR DESCRIPTION
On my setup, I need to define the gpio_in_pin for LIRC to 26. According to [raspberrypi.org](https://www.raspberrypi.org/documentation/usage/gpio-plus-and-raspi2/), RPi 2 & 3 can use GPIO up to 27.

So I propose to set the limit to 27 for gpio_in_pin and gpio_out_pin.
