### PR TITLE
Fixed missing options when TV is shut-down.

### DIFF
--- a/package/mediacenter-osmc/patches/all-005-better-cec-behaviour.patch
+++ b/package/mediacenter-osmc/patches/all-005-better-cec-behaviour.patch
@@ -29,7 +29,7 @@ index d5704b2..449f87c 100644
 -    <setting key="use_tv_menu_language" type="bool" value="1" label="36018" order="10" />
 -    <setting key="pause_playback_on_deactivate" type="bool" value="1" label="36033" configurable="0" />
 +    <setting key="cec_wake_screensaver" type="bool" value="0" label="36010" order="7" />
-+    <setting key="standby_pc_on_tv_standby" type="enum" value="36028" label="36029" order="8" lvalues="36028|13005|13011" />
++    <setting key="standby_pc_on_tv_standby" type="enum" value="36028" label="36029" order="8" lvalues="36028|13005|13011|13009|36044|36045" />
 +    <setting key="standby_tv_on_pc_standby" type="bool" value="0" label="36026" order="9" />
 +    <setting key="use_tv_menu_language" type="bool" value="0" label="36018" order="10" />
 +    <setting key="pause_playback_on_deactivate" type="bool" value="0" label="36033" configurable="0" />


### PR DESCRIPTION
The original patch removes the pause/stop/quit options, so here it is back again.