### PR TITLE
[package] [diskmount-osmc] Samba usershares: use short hostname

### DIFF
--- a/package/diskmount-osmc/files/etc/udisks-glue.conf
+++ b/package/diskmount-osmc/files/etc/udisks-glue.conf
@@ -43,7 +43,7 @@ match ntfs-partitions {
 		if [ -f /usr/bin/net ] && /bin/systemctl is-enabled samba > /dev/null 2>&1; then
 			count=120
 			while [ $count -gt 0 ]; do
-				if sudo /usr/bin/net usershare add "$(basename "%mount_point")" "%mount_point" "Auto-mount Volume" "$(hostname)\osmc:f"
+				if sudo /usr/bin/net usershare add "$(basename "%mount_point")" "%mount_point" "Auto-mount Volume" "$(hostname -s)\osmc:f"
 					then break
 				fi
 			sleep 5; let count-=5
@@ -63,7 +63,7 @@ match vfat-partitions {
 		if [ -f /usr/bin/net ] && /bin/systemctl is-enabled samba > /dev/null 2>&1; then
 			count=120
 			while [ $count -gt 0 ]; do
-				if sudo /usr/bin/net usershare add "$(basename "%mount_point")" "%mount_point" "Auto-mount Volume" "$(hostname)\osmc:f"
+				if sudo /usr/bin/net usershare add "$(basename "%mount_point")" "%mount_point" "Auto-mount Volume" "$(hostname -s)\osmc:f"
 					then break
 				fi
 			sleep 5; let count-=5
@@ -83,7 +83,7 @@ match other-partitions {
 		if [ -f /usr/bin/net ] && /bin/systemctl is-enabled samba > /dev/null 2>&1; then
 			count=120
 			while [ $count -gt 0 ]; do
-				if sudo /usr/bin/net usershare add "$(basename "%mount_point")" "%mount_point" "Auto-mount Volume" "$(hostname)\osmc:f"
+				if sudo /usr/bin/net usershare add "$(basename "%mount_point")" "%mount_point" "Auto-mount Volume" "$(hostname -s)\osmc:f"
 					then break
 				fi
 			sleep 5; let count-=5
@@ -104,7 +104,7 @@ match optical-udf {
 		if [ -f /usr/bin/net ] && /bin/systemctl is-enabled samba > /dev/null 2>&1; then
 			count=120
 			while [ $count -gt 0 ]; do
-				if sudo /usr/bin/net usershare add "$(basename "%mount_point")" "%mount_point" "Auto-mount Volume" "$(hostname)\osmc:r"
+				if sudo /usr/bin/net usershare add "$(basename "%mount_point")" "%mount_point" "Auto-mount Volume" "$(hostname -s)\osmc:r"
 					then break
 				fi
 			sleep 5; let count-=5
@@ -126,7 +126,7 @@ match optical-other {
 		if [ -f /usr/bin/net ] && /bin/systemctl is-enabled samba > /dev/null 2>&1; then
 			count=120
 			while [ $count -gt 0 ]; do
-				if sudo /usr/bin/net usershare add "$(basename "%mount_point")" "%mount_point" "Auto-mount Volume" "$(hostname)\osmc:r"
+				if sudo /usr/bin/net usershare add "$(basename "%mount_point")" "%mount_point" "Auto-mount Volume" "$(hostname -s)\osmc:r"
 					then break
 				fi
 			sleep 5; let count-=5


### PR DESCRIPTION
Samba Netbios name is the short hostname (as returned by 'hostname -s'). Without this modification, Samba usershares do not work when the machine has a FQDN (as returned by 'hostname').