### PR TITLE
Kodi stoped video player during "pause"

### DIFF
--- a/package/a2dp-app-osmc/files/usr/share/kodi/addons/service.osmc.btplayer/service.py
+++ b/package/a2dp-app-osmc/files/usr/share/kodi/addons/service.osmc.btplayer/service.py
@@ -141,7 +141,7 @@ class BTPlayer(threading.Thread):
             if "State" in changed:
                 if not changed["State"] == self.state:
                     self.state = changed["State"]
-                    if not self.state  == "active":
+                    if self.state not in ("active","idle"):
                         xbmc.stopBTPlayer()
         elif iface == "MediaPlayer1":
             if "Status" in changed:


### PR DESCRIPTION
Kodi stops video player in case:
1) audio streaming osmc => bluetooth speaker
2) watching video
3) pressing pause
in this case status is changed from "active" to "idle"  which raise xbmc.stopBTPlayer() after few minutes

issue evaluation: https://discourse.osmc.tv/t/kodi-v17-playback-crash-on-pause/22608/43