### PR TITLE
[package][mediacenter-osmc] Sync hardware and virtual keyboard layouts

### DIFF
--- a/package/mediacenter-osmc/patches/all-999-sync-hw-and-virtual-keyboards.patch
+++ b/package/mediacenter-osmc/patches/all-999-sync-hw-and-virtual-keyboards.patch
@@ -1,0 +1,612 @@
+diff --git a/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/system/keyboardlayouts/bulgarian.xml b/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/system/keyboardlayouts/bulgarian.xml
+old mode 100644
+new mode 100755
+index dee53f5..eb2df3d
+--- a/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/system/keyboardlayouts/bulgarian.xml
++++ b/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/system/keyboardlayouts/bulgarian.xml
+@@ -4,7 +4,7 @@ Please use English language names instead.
+ Default font lacks support for all characters
+ -->
+ <keyboardlayouts>
+-  <layout language="Bulgarian" layout="ЯВЕРТЪ">
++  <layout language="Bulgarian" layout="ЯВЕРТЪ" linuxkeymap="bg_bds-unicode">
+     <keyboard>
+       <row>ч1234567890</row>
+       <row>явертъуиопшщ</row>
+@@ -24,7 +24,7 @@ Default font lacks support for all characters
+       <row>`~</row>
+     </keyboard>
+   </layout>
+-  <layout language="Bulgarian" layout="АБВ">
++  <layout language="Bulgarian" layout="АБВ" linuxkeymap="bg_bds-unicode">
+     <keyboard>
+       <row>0123456789</row>
+       <row>абвгдежзий</row>
+diff --git a/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/system/keyboardlayouts/croatian.xml b/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/system/keyboardlayouts/croatian.xml
+old mode 100644
+new mode 100755
+index 3f3fca7..7dc2d70
+--- a/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/system/keyboardlayouts/croatian.xml
++++ b/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/system/keyboardlayouts/croatian.xml
+@@ -4,7 +4,7 @@ Please use English language names instead.
+ Default font lacks support for all characters
+ -->
+ <keyboardlayouts>
+-  <layout language="Croatian" layout="QWERTY">
++  <layout language="Croatian" layout="QWERTY" linuxkeymap="croat">
+     <keyboard>
+       <row>1234567890'+</row>
+       <row>qwertzuiopšđ</row>
+diff --git a/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/system/keyboardlayouts/czech.xml b/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/system/keyboardlayouts/czech.xml
+old mode 100644
+new mode 100755
+index 4c31abd..8d64d5a
+--- a/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/system/keyboardlayouts/czech.xml
++++ b/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/system/keyboardlayouts/czech.xml
+@@ -4,7 +4,7 @@ Please use English language names instead.
+ Default font lacks support for all characters
+ -->
+ <keyboardlayouts>
+-  <layout language="Czech" layout="QWERTZ">
++  <layout language="Czech" layout="QWERTZ" linuxkeymap="cz-us-qwertz">
+     <keyboard>
+       <row>ťěščřžýáíéó(</row>
+       <row>qwertzuiopú)</row>
+diff --git a/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/system/keyboardlayouts/danish.xml b/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/system/keyboardlayouts/danish.xml
+old mode 100644
+new mode 100755
+index 2ceffec..8b8f686
+--- a/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/system/keyboardlayouts/danish.xml
++++ b/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/system/keyboardlayouts/danish.xml
+@@ -4,7 +4,7 @@ Please use English language names instead.
+ Default font lacks support for all characters
+ -->
+ <keyboardlayouts>
+-  <layout language="Danish" layout="QWERTY">
++  <layout language="Danish" layout="QWERTY" linuxkeymap="dk">
+     <keyboard>
+       <row>1234567890</row>
+       <row>qwertyuiopå</row>
+diff --git a/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/system/keyboardlayouts/english.xml b/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/system/keyboardlayouts/english.xml
+old mode 100644
+new mode 100755
+index 881db17..f1941ab
+--- a/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/system/keyboardlayouts/english.xml
++++ b/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/system/keyboardlayouts/english.xml
+@@ -4,7 +4,7 @@ Please use English language names instead.
+ Default font lacks support for all characters
+ -->
+ <keyboardlayouts>
+-  <layout language="English" layout="QWERTY">
++  <layout language="English" layout="QWERTY" linuxkeymap="uk">
+     <keyboard>
+       <row>1234567890</row>
+       <row>qwertyuiop</row>
+@@ -24,7 +24,27 @@ Default font lacks support for all characters
+       <row>`~</row>
+     </keyboard>
+   </layout>
+-  <layout language="English" layout="AZERTY">
++  <layout language="English (US)" layout="QWERTY" linuxkeymap="us">
++    <keyboard>
++      <row>1234567890</row>
++      <row>qwertyuiop</row>
++      <row>asdfghjkl:</row>
++      <row>zxcvbnm./@</row>
++    </keyboard>
++    <keyboard modifiers="shift">
++      <row>1234567890</row>
++      <row>QWERTYUIOP</row>
++      <row>ASDFGHJKL:</row>
++      <row>ZXCVBNM./@</row>
++    </keyboard>
++    <keyboard modifiers="symbol,shift+symbol">
++      <row>)!@#$%^&amp;*(</row>
++      <row>[]{}-_=+;:</row>
++      <row>'",.&lt;&gt;/?\|</row>
++      <row>`~</row>
++    </keyboard>
++  </layout>
++  <layout language="English" layout="AZERTY" linuxkeymap="azerty">
+     <keyboard>
+       <row>1234567890</row>
+       <row>azertyuiop</row>
+diff --git a/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/system/keyboardlayouts/french.xml b/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/system/keyboardlayouts/french.xml
+old mode 100644
+new mode 100755
+index 630ec32..111636c
+--- a/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/system/keyboardlayouts/french.xml
++++ b/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/system/keyboardlayouts/french.xml
+@@ -4,7 +4,7 @@ Please use English language names instead.
+ Default font lacks support for all characters
+ -->
+ <keyboardlayouts>
+-  <layout language="French" layout="AZERTY">
++  <layout language="French" layout="AZERTY" linuxkeymap="fr-x11">
+     <keyboard>
+       <row>1234567890°+</row>
+       <row>azertyuiop^$</row>
+@@ -24,4 +24,4 @@ Default font lacks support for all characters
+       <row>ÀÂÇÉÈÊËÎÏÔÖÛ</row>
+     </keyboard>
+   </layout>
+-</keyboardlayouts>
+\ No newline at end of file
++</keyboardlayouts>
+diff --git a/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/system/keyboardlayouts/german.xml b/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/system/keyboardlayouts/german.xml
+old mode 100644
+new mode 100755
+index 37c2aa7..2fe1f09
+--- a/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/system/keyboardlayouts/german.xml
++++ b/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/system/keyboardlayouts/german.xml
+@@ -4,7 +4,7 @@ Please use English language names instead.
+ Default font lacks support for all characters
+ -->
+ <keyboardlayouts>
+-  <layout language="German" layout="QWERTZ">
++  <layout language="German" layout="QWERTZ" linuxkeymap="de-latin1">
+     <keyboard>
+       <row>1234567890ß</row>
+       <row>qwertzuiopü</row>
+@@ -24,7 +24,7 @@ Default font lacks support for all characters
+       <row>`~</row>
+     </keyboard>
+   </layout>
+-  <layout language="German" layout="ABC">
++  <layout language="German" layout="ABC" linuxkeymap="de-latin1">
+     <keyboard>
+       <row>1234567890ß</row>
+       <row>abcdefghijk</row>
+diff --git a/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/system/keyboardlayouts/greek.xml b/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/system/keyboardlayouts/greek.xml
+old mode 100644
+new mode 100755
+index 823133a..d13cc7c
+--- a/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/system/keyboardlayouts/greek.xml
++++ b/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/system/keyboardlayouts/greek.xml
+@@ -4,7 +4,7 @@ Please use English language names instead.
+ Default font lacks support for all characters
+ -->
+ <keyboardlayouts>
+-  <layout language="Greek" layout="QWERTY">
++  <layout language="Greek" layout="QWERTY" linuxkeymap="gr">
+     <keyboard>
+       <row>1234567890</row>
+       <row>ςερτυθιοπ</row>
+diff --git a/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/system/keyboardlayouts/hebrew.xml b/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/system/keyboardlayouts/hebrew.xml
+old mode 100644
+new mode 100755
+index 8cd23ab..b252732
+--- a/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/system/keyboardlayouts/hebrew.xml
++++ b/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/system/keyboardlayouts/hebrew.xml
+@@ -4,7 +4,7 @@ Please use English language names instead.
+ Default font lacks support for all characters
+ -->
+ <keyboardlayouts>
+-  <layout language="Hebrew" layout="QWERTY">
++  <layout language="Hebrew" layout="QWERTY" linuxkeymap="il">
+     <keyboard>
+       <row>1234567890</row>
+       <row>קראטוןםפ</row>
+@@ -24,7 +24,7 @@ Default font lacks support for all characters
+       <row>`~</row>
+     </keyboard>
+   </layout>
+-  <layout language="Hebrew" layout="ABC">
++  <layout language="Hebrew" layout="ABC" linuxkeymap="il">
+     <keyboard>
+       <row>0123456789</row>
+       <row>יטחזוהדגבא</row>
+diff --git a/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/system/keyboardlayouts/hungarian.xml b/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/system/keyboardlayouts/hungarian.xml
+old mode 100644
+new mode 100755
+index b1f433a..c3a2128
+--- a/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/system/keyboardlayouts/hungarian.xml
++++ b/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/system/keyboardlayouts/hungarian.xml
+@@ -4,7 +4,7 @@ Please use English language names instead.
+ Default font lacks support for all characters
+ -->
+ <keyboardlayouts>
+-  <layout language="Hungarian" layout="QWERTZ">
++  <layout language="Hungarian" layout="QWERTZ" linuxkeymap="hu">
+     <keyboard>
+       <row>0123456789öüó</row>
+       <row>qwertzuiopőú</row>
+diff --git a/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/system/keyboardlayouts/icelandic.xml b/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/system/keyboardlayouts/icelandic.xml
+old mode 100644
+new mode 100755
+index 7b1887d..197ef48
+--- a/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/system/keyboardlayouts/icelandic.xml
++++ b/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/system/keyboardlayouts/icelandic.xml
+@@ -4,7 +4,7 @@ Please use English language names instead.
+ Default font lacks support for all characters
+ -->
+ <keyboardlayouts>
+-  <layout language="Icelandic" layout="QWERTY">
++  <layout language="Icelandic" layout="QWERTY" linuxkeymap="is-latin1">
+     <keyboard>
+       <row>1234567890ö-</row>
+       <row>qwertyuiopð'</row>
+diff --git a/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/system/keyboardlayouts/italian.xml b/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/system/keyboardlayouts/italian.xml
+old mode 100644
+new mode 100755
+index 9545f87..1e43b90
+--- a/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/system/keyboardlayouts/italian.xml
++++ b/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/system/keyboardlayouts/italian.xml
+@@ -4,7 +4,7 @@ Please use English language names instead.
+ Default font lacks support for all characters
+ -->
+ <keyboardlayouts>
+-  <layout language="Italian" layout="QWERTY">
++  <layout language="Italian" layout="QWERTY" linuxkeymap="it">
+     <keyboard>
+       <row>1234567890'ì</row>
+       <row>qwertyuiopè+</row>
+diff --git a/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/system/keyboardlayouts/lithuanian.xml b/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/system/keyboardlayouts/lithuanian.xml
+old mode 100644
+new mode 100755
+index 9f0c839..7be853e
+--- a/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/system/keyboardlayouts/lithuanian.xml
++++ b/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/system/keyboardlayouts/lithuanian.xml
+@@ -4,7 +4,7 @@ Please use English language names instead.
+ Default font lacks support for all characters
+ -->
+ <keyboardlayouts>
+-  <layout language="Lithuanian" layout="AZERTY">
++  <layout language="Lithuanian" layout="AZERTY" linuxkeymap="lt">
+     <keyboard>
+       <row>1234567890x</row>
+       <row>ąžertyuiopįw</row>
+@@ -24,7 +24,7 @@ Default font lacks support for all characters
+       <row>`~</row>
+     </keyboard>
+   </layout>
+-  <layout language="Lithuanian" layout="QWERTY">
++  <layout language="Lithuanian" layout="QWERTY" linuxkeymap="lt.l4">
+     <keyboard>
+       <row>1234567890</row>
+       <row>qwertyuiopąč</row>
+diff --git a/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/system/keyboardlayouts/norwegian.xml b/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/system/keyboardlayouts/norwegian.xml
+old mode 100644
+new mode 100755
+index 8db7f78..48519d2
+--- a/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/system/keyboardlayouts/norwegian.xml
++++ b/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/system/keyboardlayouts/norwegian.xml
+@@ -4,7 +4,7 @@ Please use English language names instead.
+ Default font lacks support for all characters
+ -->
+ <keyboardlayouts>
+-  <layout language="Norwegian" layout="QWERTY">
++  <layout language="Norwegian" layout="QWERTY" linuxkeymap="no-latin1">
+     <keyboard>
+       <row>1234567890</row>
+       <row>qwertyuiopå</row>
+diff --git a/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/system/keyboardlayouts/polish.xml b/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/system/keyboardlayouts/polish.xml
+old mode 100644
+new mode 100755
+index 91e631e..c469cce
+--- a/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/system/keyboardlayouts/polish.xml
++++ b/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/system/keyboardlayouts/polish.xml
+@@ -4,7 +4,7 @@ Please use English language names instead.
+ Default font lacks support for all characters
+ -->
+ <keyboardlayouts>
+-  <layout language="Polish" layout="QWERTY">
++  <layout language="Polish" layout="QWERTY" linuxkeymap="pl">
+     <keyboard>
+       <row>`1234567890-</row>
+       <row>qwertyuiopąć</row>
+diff --git a/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/system/keyboardlayouts/portuguese.xml b/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/system/keyboardlayouts/portuguese.xml
+old mode 100644
+new mode 100755
+index 6730ed6..3507147
+--- a/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/system/keyboardlayouts/portuguese.xml
++++ b/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/system/keyboardlayouts/portuguese.xml
+@@ -4,7 +4,7 @@ Please use English language names instead.
+ Default font lacks support for all characters
+ -->
+ <keyboardlayouts>
+-  <layout language="Portuguese (Portugal)" layout="QWERTY">
++  <layout language="Portuguese (Portugal)" layout="QWERTY" linuxkeymap="pt-latin1">
+     <keyboard>
+       <row>\1234567890'</row>
+       <row>qwertyuiop+´</row>
+diff --git a/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/system/keyboardlayouts/romanian.xml b/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/system/keyboardlayouts/romanian.xml
+old mode 100644
+new mode 100755
+index 83defed..beb82d5
+--- a/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/system/keyboardlayouts/romanian.xml
++++ b/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/system/keyboardlayouts/romanian.xml
+@@ -4,7 +4,7 @@ Please use English language names instead.
+ Default font lacks support for all characters
+ -->
+ <keyboardlayouts>
+-  <layout language="Romanian" layout="QWERTY">
++  <layout language="Romanian" layout="QWERTY" linuxkeymap="ro">
+     <keyboard>
+       <row>1234567890</row>
+       <row>qwertyuiopăî</row>
+diff --git a/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/system/keyboardlayouts/russian.xml b/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/system/keyboardlayouts/russian.xml
+old mode 100644
+new mode 100755
+index d0c9102..3fa8a0f
+--- a/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/system/keyboardlayouts/russian.xml
++++ b/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/system/keyboardlayouts/russian.xml
+@@ -4,7 +4,7 @@ Please use English language names instead.
+ Default font lacks support for all characters
+ -->
+ <keyboardlayouts>
+-  <layout language="Russian" layout="ЙЦУКЕН">
++  <layout language="Russian" layout="ЙЦУКЕН" linuxkeymap="ru-unicode">
+     <keyboard>
+       <row>ё1234567890</row>
+       <row>йцукенгшщзхъ</row>
+@@ -24,7 +24,7 @@ Default font lacks support for all characters
+       <row>`~</row>
+     </keyboard>
+   </layout>
+-  <layout language="Russian" layout="АБВ">
++  <layout language="Russian" layout="АБВ" linuxkeymap="ru">
+     <keyboard>
+       <row>0123456789</row>
+       <row>абвгдеёжзий</row>
+diff --git a/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/system/keyboardlayouts/silesian.xml b/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/system/keyboardlayouts/silesian.xml
+old mode 100644
+new mode 100755
+index a35aab9..e12cff1
+--- a/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/system/keyboardlayouts/silesian.xml
++++ b/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/system/keyboardlayouts/silesian.xml
+@@ -4,7 +4,7 @@ Please use English language names instead.
+ Default font lacks support for all characters
+ -->
+ <keyboardlayouts>
+-  <layout language="Silesian" layout="QWERTY">
++  <layout language="Silesian" layout="QWERTY" linuxkeymap="pl">
+     <keyboard>
+       <row>ôōŏśćńłżź(</row>
+       <row>qwertzuiopã)</row>
+diff --git a/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/system/keyboardlayouts/slovak.xml b/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/system/keyboardlayouts/slovak.xml
+old mode 100644
+new mode 100755
+index 5737079..0b9a940
+--- a/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/system/keyboardlayouts/slovak.xml
++++ b/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/system/keyboardlayouts/slovak.xml
+@@ -4,7 +4,7 @@ Please use English language names instead.
+ Default font lacks support for all characters
+ -->
+ <keyboardlayouts>
+-  <layout language="Slovak" layout="QWERTZ">
++  <layout language="Slovak" layout="QWERTZ" linuxkeymap="sk-qwertz">
+     <keyboard>
+       <row>ĺľščťžýáíéó_</row>
+       <row>qwertzuiopúä</row>
+@@ -24,7 +24,7 @@ Default font lacks support for all characters
+       <row>\|&lt;&gt;,.?:-_</row>
+     </keyboard>
+   </layout>
+-  <layout language="Slovak" layout="QWERTY">
++  <layout language="Slovak" layout="QWERTY" linuxkeymap="sk-qwerty">
+     <keyboard>
+       <row>ĺľščťžýáíéó_</row>
+       <row>qwertyuiopúä</row>
+@@ -44,7 +44,7 @@ Default font lacks support for all characters
+       <row>\|&lt;&gt;,.?:-_</row>
+     </keyboard>
+   </layout>
+-  <layout language="Slovak" layout="ABC">
++  <layout language="Slovak" layout="ABC" linuxkeymap="sk-qwerty">
+     <keyboard>
+       <row>aáäbcčdďeéfg</row>
+       <row>hiíjklĺľmnňo</row>
+diff --git a/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/system/keyboardlayouts/spanish.xml b/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/system/keyboardlayouts/spanish.xml
+old mode 100644
+new mode 100755
+index 866e9b0..03ee2cd
+--- a/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/system/keyboardlayouts/spanish.xml
++++ b/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/system/keyboardlayouts/spanish.xml
+@@ -4,7 +4,7 @@ Please use English language names instead.
+ Default font lacks support for all characters
+ -->
+ <keyboardlayouts>
+-  <layout language="Spanish" layout="QWERTY">
++  <layout language="Spanish" layout="QWERTY" linuxkeymap="es">
+     <keyboard>
+       <row>1234567890'¡</row>
+       <row>qwertyuiop`+</row>
+diff --git a/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/system/keyboardlayouts/swedish.xml b/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/system/keyboardlayouts/swedish.xml
+old mode 100644
+new mode 100755
+index 62f920c..fb436e5
+--- a/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/system/keyboardlayouts/swedish.xml
++++ b/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/system/keyboardlayouts/swedish.xml
+@@ -4,7 +4,7 @@ Please use English language names instead.
+ Default font lacks support for all characters
+ -->
+ <keyboardlayouts>
+-  <layout language="Swedish" layout="QWERTY">
++  <layout language="Swedish" layout="QWERTY" linuxkeymap="se-latin1">
+     <keyboard>
+       <row>1234567890</row>
+       <row>qwertyuiopå</row>
+diff --git a/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/system/keyboardlayouts/turkish.xml b/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/system/keyboardlayouts/turkish.xml
+old mode 100644
+new mode 100755
+index 3a123db..d7f2d5b
+--- a/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/system/keyboardlayouts/turkish.xml
++++ b/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/system/keyboardlayouts/turkish.xml
+@@ -4,7 +4,7 @@ Please use English language names instead.
+ Default font lacks support for all characters
+ -->
+ <keyboardlayouts>
+-  <layout language="Turkish" layout="QWERTY">
++  <layout language="Turkish" layout="QWERTY" linuxkeymap="tr_q-latin5">
+     <keyboard>
+       <row>1234567890</row>
+       <row>qwertyuıopğü</row>
+diff --git a/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/system/keyboardlayouts/ukrainian.xml b/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/system/keyboardlayouts/ukrainian.xml
+old mode 100644
+new mode 100755
+index b187f5a..6c8158a
+--- a/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/system/keyboardlayouts/ukrainian.xml
++++ b/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/system/keyboardlayouts/ukrainian.xml
+@@ -4,7 +4,7 @@ Please use English language names instead.
+ Default font lacks support for all characters
+ -->
+ <keyboardlayouts>
+-  <layout language="Ukrainian" layout="ЙЦУКЕН">
++  <layout language="Ukrainian" layout="ЙЦУКЕН" linuxkeymap="ua-utf">
+     <keyboard>
+       <row>'1234567890</row>
+       <row>йцукенгшщзхї</row>
+@@ -24,7 +24,7 @@ Default font lacks support for all characters
+       <row>`~</row>
+     </keyboard>
+   </layout>
+-  <layout language="Ukrainian" layout="АБВ">
++  <layout language="Ukrainian" layout="АБВ" linuxkeymap="ua-utf">
+     <keyboard>
+       <row>0123456789</row>
+       <row>абвгґдеєжзиі</row>
+diff --git a/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/xbmc/dialogs/GUIDialogKeyboardGeneric.cpp b/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/xbmc/dialogs/GUIDialogKeyboardGeneric.cpp
+old mode 100644
+new mode 100755
+index f011a4e..75bd6f7
+--- a/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/xbmc/dialogs/GUIDialogKeyboardGeneric.cpp
++++ b/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/xbmc/dialogs/GUIDialogKeyboardGeneric.cpp
+@@ -38,6 +38,9 @@
+ #include "messaging/ApplicationMessenger.h"
+ #include "utils/CharsetConverter.h"
+ #include "windowing/WindowingFactory.h"
++#include "dialogs/GUIDialogKaiToast.h"
++#include "utils/log.h"
++#include "filesystem/SpecialProtocol.h"
+ 
+ using namespace KODI::MESSAGING;
+ 
+@@ -140,8 +143,42 @@ void CGUIDialogKeyboardGeneric::OnInitWindow()
+       m_layouts.push_back(keyboardLayout->second);
+   }
+ 
+-  // set alphabetic (capitals)
+-  UpdateButtons();
++  // read hardware keymap
++  char systemkeymap[20] = "uk"; /* UK as default */
++  char *kblayout_path = NULL;
++  std::string homedir = CSpecialProtocol::TranslatePath("special://envhome/");
++  if (asprintf(&kblayout_path, "%s%s", homedir.c_str(), ".kblayout") != -1)
++  {
++    FILE *kblayout_fp = fopen(kblayout_path, "r");
++    if (kblayout_fp)
++    {
++      fgets(systemkeymap, 20, kblayout_fp);
++      fclose(kblayout_fp);
++    }
++      free(kblayout_path);
++  }
++  CLog::Log(LOGDEBUG, "CGUIDialogKeyboardGeneric::OnInitWindow: system keymap read as %s", systemkeymap);
++  std::string strkeymap = systemkeymap;
++  while (m_currentLayout < m_layouts.size())
++  {
++    CLog::Log(LOGDEBUG, "CGUIDialogKeyboardGeneric::OnInitWindow: CurrentLayout %u, keymap %s ", m_currentLayout,  m_layouts[m_currentLayout].GetKeymap().c_str());
++    if (strkeymap.compare(0,m_layouts[m_currentLayout].GetKeymap().length(),m_layouts[m_currentLayout].GetKeymap()) == 0)
++      break;
++    m_currentLayout++;
++  }
++  if (m_currentLayout >= m_layouts.size())
++  {
++    // hardware keymap doesn't match any of the virtual keyboard layouts available
++    CLog::Log(LOGWARNING, "CGUIDialogKeyboardGeneric::OnInitWindow: Cannot find matching layout for keymap %s", systemkeymap);
++    OnLayout();
++  }
++  else
++  {
++    CLog::Log(LOGINFO, "CGUIDialogKeyboardGeneric::OnInitWindow: CurrentLayout set to %s %s for %s", \
++        m_layouts[m_currentLayout].GetLanguage().c_str(), m_layouts[m_currentLayout].GetLayout().c_str(),  m_layouts[m_currentLayout].GetKeymap().c_str());
++    // set alphabetic (capitals)
++    UpdateButtons();
++  }
+ 
+   // set heading
+   if (!m_strHeading.empty())
+@@ -524,6 +561,29 @@ void CGUIDialogKeyboardGeneric::OnLayout()
+   m_currentLayout++;
+   if (m_currentLayout >= m_layouts.size())
+     m_currentLayout = 0;
++  CKeyboardLayout newlayout = m_layouts.empty() ? CKeyboardLayout() : m_layouts[m_currentLayout];
++  std::string strkeymap = newlayout.GetKeymap();
++  if (strkeymap != ""){
++    std::string command = "/usr/bin/sudo /usr/bin/loadkeys ";
++    command += strkeymap;
++    int ret = system(command.c_str());
++    CLog::Log(LOGDEBUG, "CGUIDialogKeyboardGeneric::OnLayout:loadkeys returned %u for %s", ret, command.c_str());
++    if (! ret) 
++    {
++      CLog::Log(LOGINFO, "CGUIDialogKeyboardGeneric::OnLayout: CurrentLayout set to %s %s for %s", \
++        m_layouts[m_currentLayout].GetLanguage().c_str(), m_layouts[m_currentLayout].GetLayout().c_str(),  m_layouts[m_currentLayout].GetKeymap().c_str());
++      CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info, "Keyboard", "Keymap " + strkeymap + " loaded");
++      command = "/bin/echo ";
++      std::string command2 = " > /home/osmc/.kblayout";
++      command = command + strkeymap + command2;
++      ret = system(command.c_str());
++      CLog::Log(LOGDEBUG, "CGUIDialogKeyboardGeneric::OnLayout:echo returned %u for %s", ret, command.c_str());
++    } else
++    {
++      CLog::Log(LOGWARNING, "CGUIDialogKeyboardGeneric::OnLayout: Cannot find keymap %s", strkeymap.c_str());
++      CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info, "Keyboard", "Keymap " + strkeymap + " not found");
++    }
++  }
+   UpdateButtons();
+ }
+ 
+diff --git a/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/xbmc/input/KeyboardLayout.cpp b/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/xbmc/input/KeyboardLayout.cpp
+old mode 100644
+new mode 100755
+index 30717de..f1a6e2b
+--- a/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/xbmc/input/KeyboardLayout.cpp
++++ b/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/xbmc/input/KeyboardLayout.cpp
+@@ -20,6 +20,7 @@
+ 
+ #include <algorithm>
+ #include <set>
++#include <stdlib.h>
+ 
+ #include "KeyboardLayout.h"
+ #include "guilib/LocalizeStrings.h"
+@@ -67,6 +68,16 @@ bool CKeyboardLayout::Load(const TiXmlElement* element)
+     return false;
+   }
+ 
++  const char* keymap = element->Attribute("linuxkeymap");
++  if (keymap == NULL)
++  {
++    CLog::Log(LOGWARNING, "CKeyboardLayout: empty \"linuxkeymap\" attribute, loading default uk map");
++	m_linuxkeymap = "uk";
++  } else
++  {
++    m_linuxkeymap = keymap;
++  }
++
+   const TiXmlElement *keyboard = element->FirstChildElement("keyboard");
+   if (element->Attribute("codingtable"))
+     m_codingtable = IInputCodingTablePtr(CInputCodingTableFactory::CreateCodingTable(element->Attribute("codingtable"), element));
+diff --git a/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/xbmc/input/KeyboardLayout.h b/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/xbmc/input/KeyboardLayout.h
+old mode 100644
+new mode 100755
+index fd3cd83..dc9f2de
+--- a/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/xbmc/input/KeyboardLayout.h
++++ b/package/mediacenter-osmc/src/xbmc-7fc6da0c87414d2ba20055e084adc10546a15b7c/xbmc/input/KeyboardLayout.h
+@@ -40,6 +40,7 @@ public:
+   std::string GetName() const;
+   const std::string& GetLanguage() const { return m_language; }
+   const std::string& GetLayout() const { return m_layout; }
++  const std::string& GetKeymap() const { return m_linuxkeymap; }
+ 
+   enum ModifierKey
+   {
+@@ -58,6 +59,7 @@ private:
+ 
+   std::string m_language;
+   std::string m_layout;
++  std::string m_linuxkeymap;
+   Keyboards m_keyboards;
+   IInputCodingTablePtr m_codingtable;
+ };


### PR DESCRIPTION
Hardware keyboard layouts synchronised with the keyboard layout setting in Kodi's virtual keyboard.
Requires keymaps stored in the Debian default /usr/share/keymaps/ tree.
Requires PR #395 changes to LinuxInputDevices for non-ascii keys to be recognised.
Keymap alias is saved in $HOME/.kblayout and should be loaded at boot for correct mapping of keyboard control keys before the first time the virtual keyboard is invoked.
[loadkeys.service.txt](https://github.com/osmc/osmc/files/1352611/loadkeys.service.txt)

