### PR TITLE
[package] [mediacenter-addon-osmc] Add logging of APT sources.list.d

### DIFF
--- a/package/mediacenter-addon-osmc/files/DEBIAN/control
+++ b/package/mediacenter-addon-osmc/files/DEBIAN/control
@@ -1,6 +1,6 @@
 Origin: OSMC
 Package: mediacenter-addon-osmc
-Version: 3.0.651
+Version: 3.0.652
 Section: utils
 Essential: No
 Priority: optional
@@ -8,3 +8,4 @@ Architecture: all
 Depends: python-apt, python-pexpect, python-requests
 Maintainer: Sam G Nazarko <email@samnazarko.co.uk>
 Description: OSMC addon for mediacenter
+Installed-Size: 21047

--- a/package/mediacenter-addon-osmc/src/script.module.osmccommon/resources/lib/grablogs.py
+++ b/package/mediacenter-addon-osmc/src/script.module.osmccommon/resources/lib/grablogs.py
@@ -184,7 +184,7 @@ SETS =	{
 
 		'apt' 				: { 'order' : 10, 	
 								'active': False, 
-								'help'  : 'APT term.log, history.log, sources.list, apt.conf.d, preferences.d',
+								'help'  : 'APT term.log, history.log, sources.list, apt.conf.d, preferences.d, sources.list.d',
 								'dest'  : 'apt',
 								'action': 'store_true',
 								'flags' : ['-a', '--apt'],
@@ -218,7 +218,13 @@ SETS =	{
 												'key' : 'vSKj25Lq',
 												'ltyp': 'cl_log', 
 												'actn': 'ls -al /etc/apt/preferences.d',
-											},																																	
+											},
+                                                                                        {
+                                                                                                'name': 'APT sources.list.d',
+                                                                                                'key' : 'KjLq37hD',
+                                                                                                'ltyp': 'cl_log',
+                                                                                                'actn': 'ls -al /etc/apt/sources.list.d',
+                                                                                        },																																	
 										  ], 										 
 								},
 

--- a/package/mediacenter-addon-osmc/src/script.module.osmcsetting.logging/resources/lib/grablogs.py
+++ b/package/mediacenter-addon-osmc/src/script.module.osmcsetting.logging/resources/lib/grablogs.py
@@ -222,6 +222,12 @@ SETS =  {
                                                 'ltyp': 'cl_log',
                                                 'actn': 'ls -al /etc/apt/preferences.d',
                                             },
+                                            {
+                                                'name': 'APT sources.list.d',
+                                                'key' : 'KjLq37hD',
+                                                'ltyp': 'cl_log',
+                                                'actn': 'ls -al /etc/apt/sources.list.d',
+                                            },
                                           ],
                                 },
 


### PR DESCRIPTION
Not sure about package/mediacenter-addon-osmc/src/script.module.osmccommon/resources/lib/grablogs.py line 221 change, I think it was a $ sign which should now be in 227