### PR TITLE
Adding eventlircd maps for FreeWay T3 RF/IR Air-Mouse.

### DIFF
--- a/package/eventlircd-osmc/files/etc/eventlircd.d/t3_airmouse.evmap
+++ b/package/eventlircd-osmc/files/etc/eventlircd.d/t3_airmouse.evmap
@@ -1,0 +1,8 @@
+# Key remap for T3 RF/IR Air-Mouse
+# https://www.amazon.com/Keenest-Wireless-Keyboard-Multifunctional-3-Gsensor/dp/B01CEWV2BW/189-2112597-2293766
+KEY_UNKNOWN             = KEY_F1        # Rather unfortunately an actual key on this remote maps to KEY_UNKNOWN
+                                        # which cannot, to my knowledge, be mapped to a function in Kodi.
+KEY_F4                  = KEY_RED
+KEY_F5                  = KEY_GREEN
+KEY_F6                  = KEY_YELLOW
+KEY_F7                  = KEY_BLUE

--- a/package/eventlircd-osmc/files/lib/udev/rules.d/98-eventlircd.rules
+++ b/package/eventlircd-osmc/files/lib/udev/rules.d/98-eventlircd.rules
@@ -215,6 +215,12 @@ ENV{ID_VENDOR_ID}=="2017", ENV{ID_MODEL_ID}=="1688", \
   ENV{eventlircd_enable}="true", \
   ENV{eventlircd_evmap}="osmc_rf2.evmap"
 
+# FreeWay T3 RF/IR Air-Mouse remote
+# https://www.amazon.com/Keenest-Wireless-Keyboard-Multifunctional-3-Gsensor/dp/B01CEWV2BW/189-2112597-2293766
+ENV{ID_VENDOR_ID}=="1d57", ENV{ID_MODEL_ID}=="ad03", \
+  ENV{eventlircd_enable}="true", \
+  ENV{eventlircd_evmap}="t3_airmouse.evmap"
+
 # Enable wake-on-usb for the USB remotes.
 ENV{eventlircd_enable}=="true", RUN+="wakeup_enable"
 


### PR DESCRIPTION
This particular one seems to go by many brand names online. Info and pictures on one of these can be found [here](https://www.amazon.com/Keenest-Wireless-Keyboard-Multifunctional-3-Gsensor/dp/B01CEWV2BW/189-2112597-2293766)

This is to solve a question I started at the OSMC forum [here](https://discourse.osmc.tv/t/custom-hwdb-not-working/54550).