### PR TITLE
[package] [mediacenter-addon-osmc] Fix bugs with the MySQL admin page…

### DIFF
--- a/package/mediacenter-addon-osmc/files/DEBIAN/control
+++ b/package/mediacenter-addon-osmc/files/DEBIAN/control
@@ -1,6 +1,6 @@
 Origin: OSMC
 Package: mediacenter-addon-osmc
-Version: 3.0.655
+Version: 3.0.656
 Section: utils
 Essential: No
 Priority: optional

--- a/package/mediacenter-addon-osmc/src/script.module.osmcsetting.networking/resources/lib/networking_gui.py
+++ b/package/mediacenter-addon-osmc/src/script.module.osmcsetting.networking/resources/lib/networking_gui.py
@@ -686,7 +686,7 @@ class networking_gui(xbmcgui.WindowXMLDialog):
 
             name.setLabel(video.get('name', 'MyVideos'))
             host.setLabel(video.get('host', '___ : ___ : ___ : ___'))
-            port.setLabel(video.get('port', ''))
+            port.setLabel(video.get('port', '3306'))
             user.setLabel(video.get('user', 'kodi'))
             try:
                 pswd.setLabel('*' * len(video.get('pass', 'kodi')))
@@ -694,8 +694,14 @@ class networking_gui(xbmcgui.WindowXMLDialog):
             except:
                 pswd.setLabel('kodi')
                 hpwd.setLabel('kodi')
-            impw.setSelected(vidlb.get('importwatchedstate', 'true') == 'true')
-            impr.setSelected(vidlb.get('importresumepoint', 'true') == 'true')
+            try:
+                impw.setSelected(vidlb.get('importwatchedstate', 'true') == 'true')
+            except:
+                impw.setSelected(False)
+            try:
+                impr.setSelected(vidlb.get('importresumepoint', 'true') == 'true')
+            except:
+                impr.setSelected(False)
 
         else:
             self.getControl(MYSQL_VIDEO_TOGGLE).setSelected(False)
@@ -708,7 +714,7 @@ class networking_gui(xbmcgui.WindowXMLDialog):
 
             name.setLabel(music.get('name', 'MyMusic'))
             host.setLabel(music.get('host', '___ : ___ : ___ : ___'))
-            port.setLabel(music.get('port', ''))
+            port.setLabel(music.get('port', '3306'))
             user.setLabel(music.get('user', 'kodi'))
             try:
                 pswd.setLabel('*' * len(music.get('pass', 'kodi')))
@@ -735,10 +741,14 @@ class networking_gui(xbmcgui.WindowXMLDialog):
 
         if self.getControl(MYSQL_VIDEO_TOGGLE).isSelected():
 
+            defaults = {'name': 'MyVideos',
+                        'port': '3306'}
             for sql_item, ctl in zip(sql_subitems, MYSQL_VIDEO_VALUES):
                 if ctl in MYSQL_PASS:
                     ctl -= 100000
                 video[sql_item] = self.getControl(ctl).getLabel()
+                if sql_item in defaults and not video[sql_item]:
+                    video[sql_item] = defaults[sql_item]
 
                 log('ctl %s : sql item %s : %s' %(ctl, sql_item, self.getControl(ctl).getLabel()))
     
@@ -769,10 +779,14 @@ class networking_gui(xbmcgui.WindowXMLDialog):
 
         if self.getControl(MYSQL_MUSIC_TOGGLE).isSelected():
 
+            defaults = {'name': 'MyMusic',
+                        'port': '3306'}
             for sql_item, ctl in zip(sql_subitems, MYSQL_MUSIC_VALUES):
                 if ctl in MYSQL_PASS:
                     ctl = ctl - 100000
                 music[sql_item] = self.getControl(ctl).getLabel()
+                if sql_item in defaults and not music[sql_item]:
+                    music[sql_item] = defaults[sql_item]
 
             sub_dict['musicdatabase'] = music
 
@@ -789,7 +803,7 @@ class networking_gui(xbmcgui.WindowXMLDialog):
         ''' Takes a dictionary and writes it to the advancedsettings.xml file '''
 
         # check the dictionary to see if it is valid
-        dictionary_valid, invalidity_type = self.ASE.validate_advset_dict(dictionary)
+        dictionary_valid, invalidity_type = self.ASE.validate_advset_dict(dictionary, no_pw_ok=True)
 
         if not dictionary_valid:
             if invalidity_type == 'missing mysql':

--- a/package/mediacenter-addon-osmc/src/script.module.osmcsetting.networking/resources/lib/osmc_advset_editor.py
+++ b/package/mediacenter-addon-osmc/src/script.module.osmcsetting.networking/resources/lib/osmc_advset_editor.py
@@ -89,7 +89,7 @@ class AdvancedSettingsEditor(object):
 		return False
 
 
-	def validate_advset_dict(self, dictionary, reject_empty=False, exclude_name=False):
+	def validate_advset_dict(self, dictionary, reject_empty=False, exclude_name=False, no_pw_ok=False):
 		''' Checks whether the provided dictionary is fully populated with MySQL settings info.
 			If reject_empty is False, then Blank dictionaries are rejected, but dictionaries with no video or music database dicts are passed.
 			If reject_empty is True,  then Blank dictionaries are rejected, AND dictionaries with no video or music database dicts are also rejected.
@@ -106,17 +106,22 @@ class AdvancedSettingsEditor(object):
 		else:
 			sql_subitems = ['name', 'host', 'port', 'user', 'pass']
 
+                if no_pw_ok:
+                        sql_subitems.remove('pass') # Don't require a password
+
 		if 'videodatabase' in main:
 			# fail if the items aren't filled in or are the default up value
 			for item in sql_subitems:
 				subitem = main.get('videodatabase',{}).get(item, False)
 				if not subitem or subitem == '___ : ___ : ___ : ___':
-					return False, 'missing mysql'
+                                        self.log('Missing MySQL Video setting: {}'.format(item))
+			                return False, 'missing mysql'
 
 		if 'musicdatabase' in main:
 			for item in sql_subitems:
 				subitem = main.get('musicdatabase',{}).get(item, False)
 				if not subitem or subitem == '___ : ___ : ___ : ___':
+                                        self.log('Missing MySQL Music setting: {}'.format(item))
 					return False, 'missing mysql'
 
 		if reject_empty:

--- a/package/mediacenter-addon-osmc/src/script.module.osmcsetting.networking/resources/skins/Default/1080i/network_gui.xml
+++ b/package/mediacenter-addon-osmc/src/script.module.osmcsetting.networking/resources/skins/Default/1080i/network_gui.xml
@@ -1737,7 +1737,7 @@
                         <align>right</align>
                         <aligny>center</aligny>
                         <visible>!Control.HasFocus(10513)+Control.isVisible(10513)</visible>
-                        <label>-</label>
+                        <label>3306</label>
                         <posx>530</posx>
                         <posy>180</posy>
                         <width>650</width>
@@ -2104,7 +2104,7 @@
                         <align>right</align>
                         <aligny>center</aligny>
                         <visible>!Control.HasFocus(10523)+Control.isVisible(10523)</visible>
-                        <label>-</label>
+                        <label>3306</label>
                         <posx>530</posx>
                         <posy>180</posy>
                         <width>650</width>

--- a/package/mediacenter-addon-osmc/src/script.module.osmcsetting.networking/resources/skins/Default/1080i/network_gui_720.xml
+++ b/package/mediacenter-addon-osmc/src/script.module.osmcsetting.networking/resources/skins/Default/1080i/network_gui_720.xml
@@ -1737,7 +1737,7 @@
                         <align>right</align>
                         <aligny>center</aligny>
                         <visible>!Control.HasFocus(10513)+Control.isVisible(10513)</visible>
-                        <label>-</label>
+                        <label>3306</label>
                         <posx>530</posx>
                         <posy>180</posy>
                         <width>650</width>
@@ -2104,7 +2104,7 @@
                         <align>right</align>
                         <aligny>center</aligny>
                         <visible>!Control.HasFocus(10523)+Control.isVisible(10523)</visible>
-                        <label>-</label>
+                        <label>3306</label>
                         <posx>530</posx>
                         <posy>180</posy>
                         <width>650</width>


### PR DESCRIPTION
… and enhancements

Fixed a problem when the user had a advancedsettings without the import
options set caused display corruption and prevented the settings from
being saved.
Fixed bug where settings were not saved if the default database names
were used.
If port is not specified, defaults to 3306
Allows empty MySQL password.
Added logging if there are missing settings.