### PR TITLE
Support Geniatech HDStar v3

### DIFF
--- a/package/kernel-osmc/patches/rbp-038-GeniatechHDStar3.patch
+++ b/package/kernel-osmc/patches/rbp-038-GeniatechHDStar3.patch
@@ -1,0 +1,295 @@
+--- a/drivers/media/dvb-frontends/ds3000.c
++++ b/drivers/media/dvb-frontends/ds3000.c
+@@ -836,7 +836,7 @@ struct dvb_frontend *ds3000_attach(const struct ds3000_config *config,
+ 				    struct i2c_adapter *i2c)
+ {
+ 	struct ds3000_state *state = NULL;
+-	int ret;
++	int ret, ver;
+ 
+ 	dprintk("%s\n", __func__);
+ 
+@@ -853,8 +853,9 @@ struct dvb_frontend *ds3000_attach(const struct ds3000_config *config,
+ 
+ 	/* check if the demod is present */
+ 	ret = ds3000_readreg(state, 0x00) & 0xfe;
+-	if (ret != 0xe0) {
+-		printk(KERN_ERR "Invalid probe, probably not a DS3000\n");
++        ver = ds3000_readreg(state, 0x01);
++        if (ret != 0xe0 || ver != 0xc0) {
++                printk(KERN_ERR "Invalid probe, probably not a DS300x\n");
+ 		goto error3;
+ 	}
+ 
+--- a/drivers/media/usb/dvb-usb/dw2102.c
++++ b/drivers/media/usb/dvb-usb/dw2102.c
+@@ -1380,65 +1380,6 @@ static int prof_7500_frontend_attach(struct dvb_usb_adapter *d)
+ 	return 0;
+ }
+ 
+-static int su3000_frontend_attach(struct dvb_usb_adapter *adap)
+-{
+-	struct dvb_usb_device *d = adap->dev;
+-	struct dw2102_state *state = d->priv;
+-
+-	mutex_lock(&d->data_mutex);
+-
+-	state->data[0] = 0xe;
+-	state->data[1] = 0x80;
+-	state->data[2] = 0;
+-
+-	if (dvb_usb_generic_rw(d, state->data, 3, state->data, 1, 0) < 0)
+-		err("command 0x0e transfer failed.");
+-
+-	state->data[0] = 0xe;
+-	state->data[1] = 0x02;
+-	state->data[2] = 1;
+-
+-	if (dvb_usb_generic_rw(d, state->data, 3, state->data, 1, 0) < 0)
+-		err("command 0x0e transfer failed.");
+-	msleep(300);
+-
+-	state->data[0] = 0xe;
+-	state->data[1] = 0x83;
+-	state->data[2] = 0;
+-
+-	if (dvb_usb_generic_rw(d, state->data, 3, state->data, 1, 0) < 0)
+-		err("command 0x0e transfer failed.");
+-
+-	state->data[0] = 0xe;
+-	state->data[1] = 0x83;
+-	state->data[2] = 1;
+-
+-	if (dvb_usb_generic_rw(d, state->data, 3, state->data, 1, 0) < 0)
+-		err("command 0x0e transfer failed.");
+-
+-	state->data[0] = 0x51;
+-
+-	if (dvb_usb_generic_rw(d, state->data, 1, state->data, 1, 0) < 0)
+-		err("command 0x51 transfer failed.");
+-
+-	mutex_unlock(&d->data_mutex);
+-
+-	adap->fe_adap[0].fe = dvb_attach(ds3000_attach, &su3000_ds3000_config,
+-					&d->i2c_adap);
+-	if (adap->fe_adap[0].fe == NULL)
+-		return -EIO;
+-
+-	if (dvb_attach(ts2020_attach, adap->fe_adap[0].fe,
+-				&dw2104_ts2020_config,
+-				&d->i2c_adap)) {
+-		info("Attached DS3000/TS2020!");
+-		return 0;
+-	}
+-
+-	info("Failed to attach DS3000/TS2020!");
+-	return -EIO;
+-}
+-
+ static int t220_frontend_attach(struct dvb_usb_adapter *adap)
+ {
+ 	struct dvb_usb_device *d = adap->dev;
+@@ -1529,7 +1470,7 @@ static int m88rs2000_frontend_attach(struct dvb_usb_adapter *adap)
+ 	return -EIO;
+ }
+ 
+-static int tt_s2_4600_frontend_attach(struct dvb_usb_adapter *adap)
++static int su3000_frontend_attach(struct dvb_usb_adapter *adap)
+ {
+ 	struct dvb_usb_device *d = adap->dev;
+ 	struct dw2102_state *state = d->priv;
+@@ -1577,6 +1518,21 @@ static int tt_s2_4600_frontend_attach(struct dvb_usb_adapter *adap)
+ 
+ 	mutex_unlock(&d->data_mutex);
+ 
++	/* First try ds300x version */
++	adap->fe_adap[0].fe = dvb_attach(ds3000_attach, &su3000_ds3000_config,
++					&d->i2c_adap);
++	if (adap->fe_adap[0].fe == NULL)
++		goto attach2;
++
++	if (!dvb_attach(ts2020_attach, adap->fe_adap[0].fe,
++				&dw2104_ts2020_config,
++				&d->i2c_adap)) {
++		dvb_frontend_detach(adap->fe_adap[0].fe);
++		return -ENODEV;
++	}
++	goto attach3;
++
++attach2:
+ 	/* attach demod */
+ 	m88ds3103_pdata.clk = 27000000;
+ 	m88ds3103_pdata.i2c_wr_max = 33;
+@@ -1632,7 +1588,7 @@ static int tt_s2_4600_frontend_attach(struct dvb_usb_adapter *adap)
+ 			adap->fe_adap[0].fe->ops.tuner_ops.get_rf_strength;
+ 
+ 	state->i2c_client_tuner = client;
+-
++attach3:
+ 	/* hook fe: need to resync the slave fifo when signal locks */
+ 	state->fe_read_status = adap->fe_adap[0].fe->ops.read_status;
+ 	adap->fe_adap[0].fe->ops.read_status = tt_s2_4600_read_status;
+@@ -1748,7 +1704,6 @@ enum dw2102_table_entry {
+ 	TECHNOTREND_S2_4600,
+ 	TEVII_S482_1,
+ 	TEVII_S482_2,
+-	TERRATEC_CINERGY_S2_BOX,
+ 	TEVII_S662
+ };
+ 
+@@ -1779,7 +1734,6 @@ static struct usb_device_id dw2102_table[] = {
+ 		USB_PID_TECHNOTREND_CONNECT_S2_4600)},
+ 	[TEVII_S482_1] = {USB_DEVICE(0x9022, 0xd483)},
+ 	[TEVII_S482_2] = {USB_DEVICE(0x9022, 0xd484)},
+-	[TERRATEC_CINERGY_S2_BOX] = {USB_DEVICE(USB_VID_TERRATEC, 0x0105)},
+ 	[TEVII_S662] = {USB_DEVICE(0x9022, USB_PID_TEVII_S662)},
+ 	{ }
+ };
+@@ -2189,20 +2143,24 @@ static struct dvb_usb_device_properties su3000_properties = {
+ 		}},
+ 		}
+ 	},
+-	.num_device_descs = 6,
++	.num_device_descs = 7,
+ 	.devices = {
+ 		{ "SU3000HD DVB-S USB2.0",
+ 			{ &dw2102_table[GENIATECH_SU3000], NULL },
+ 			{ NULL },
+ 		},
+-		{ "Terratec Cinergy S2 USB HD",
+-			{ &dw2102_table[TERRATEC_CINERGY_S2], NULL },
+-			{ NULL },
+-		},
+ 		{ "X3M TV SPC1400HD PCI",
+ 			{ &dw2102_table[X3M_SPC1400HD], NULL },
+ 			{ NULL },
+ 		},
++		{ "GOTVIEW Satellite HD",
++			{ &dw2102_table[GOTVIEW_SAT_HD], NULL },
++			{ NULL },
++		},
++		{ "Terratec Cinergy S2 USB HD",
++			{ &dw2102_table[TERRATEC_CINERGY_S2], NULL },
++			{ NULL },
++		},
+ 		{ "Terratec Cinergy S2 USB HD Rev.2",
+ 			{ &dw2102_table[TERRATEC_CINERGY_S2_R2], NULL },
+ 			{ NULL },
+@@ -2211,8 +2169,8 @@ static struct dvb_usb_device_properties su3000_properties = {
+ 			{ &dw2102_table[TERRATEC_CINERGY_S2_R3], NULL },
+ 			{ NULL },
+ 		},
+-		{ "GOTVIEW Satellite HD",
+-			{ &dw2102_table[GOTVIEW_SAT_HD], NULL },
++		{ "Terratec Cinergy S2 USB HD Rev.4",
++			{ &dw2102_table[TERRATEC_CINERGY_S2_R4], NULL },
+ 			{ NULL },
+ 		},
+ 	}
+@@ -2293,7 +2251,7 @@ static struct dvb_usb_device_properties tt_s2_4600_properties = {
+ 		.num_frontends = 1,
+ 		.fe = {{
+ 			.streaming_ctrl   = su3000_streaming_ctrl,
+-			.frontend_attach  = tt_s2_4600_frontend_attach,
++			.frontend_attach  = su3000_frontend_attach,
+ 			.stream = {
+ 				.type = USB_BULK,
+ 				.count = 8,
+@@ -2307,12 +2265,57 @@ static struct dvb_usb_device_properties tt_s2_4600_properties = {
+ 		} },
+ 		}
+ 	},
+-	.num_device_descs = 5,
++	.num_device_descs = 1,
+ 	.devices = {
+ 		{ "TechnoTrend TT-connect S2-4600",
+ 			{ &dw2102_table[TECHNOTREND_S2_4600], NULL },
+ 			{ NULL },
+ 		},
++	}
++};
++
++static struct dvb_usb_device_properties tevii_properties = {
++	.caps = DVB_USB_IS_AN_I2C_ADAPTER,
++	.usb_ctrl = DEVICE_SPECIFIC,
++	.size_of_priv = sizeof(struct dw2102_state),
++	.power_ctrl = su3000_power_ctrl,
++	.num_adapters = 1,
++	.identify_state	= su3000_identify_state,
++	.i2c_algo = &su3000_i2c_algo,
++
++	.rc.core = {
++		.rc_interval = 250,
++		.rc_codes = RC_MAP_TEVII_NEC,
++		.module_name = "dw2102",
++		.allowed_protos   = RC_PROTO_BIT_NEC,
++		.rc_query = su3000_rc_query,
++	},
++
++	.read_mac_address = su3000_read_mac_address,
++
++	.generic_bulk_ctrl_endpoint = 0x01,
++
++	.adapter = {
++		{
++		.num_frontends = 1,
++		.fe = {{
++			.streaming_ctrl   = su3000_streaming_ctrl,
++			.frontend_attach  = su3000_frontend_attach,
++			.stream = {
++				.type = USB_BULK,
++				.count = 8,
++				.endpoint = 0x82,
++				.u = {
++					.bulk = {
++						.buffersize = 4096,
++					}
++				}
++			}
++		} },
++		}
++	},
++	.num_device_descs = 3,
++	.devices = {
+ 		{ "TeVii S482 (tuner 1)",
+ 			{ &dw2102_table[TEVII_S482_1], NULL },
+ 			{ NULL },
+@@ -2321,10 +2324,6 @@ static struct dvb_usb_device_properties tt_s2_4600_properties = {
+ 			{ &dw2102_table[TEVII_S482_2], NULL },
+ 			{ NULL },
+ 		},
+-		{ "Terratec Cinergy S2 USB BOX",
+-			{ &dw2102_table[TERRATEC_CINERGY_S2_BOX], NULL },
+-			{ NULL },
+-		},
+ 		{ "TeVii S662",
+ 			{ &dw2102_table[TEVII_S662], NULL },
+ 			{ NULL },
+@@ -2404,6 +2403,8 @@ static int dw2102_probe(struct usb_interface *intf,
+ 	    0 == dvb_usb_device_init(intf, &t220_properties,
+ 			 THIS_MODULE, NULL, adapter_nr) ||
+ 	    0 == dvb_usb_device_init(intf, &tt_s2_4600_properties,
++			THIS_MODULE, NULL, adapter_nr) ||
++	    0 == dvb_usb_device_init(intf, &tevii_properties,
+ 			 THIS_MODULE, NULL, adapter_nr))
+ 		return 0;
+ 
+--- a/drivers/media/dvb-frontends/m88ds3103.c
++++ b/drivers/media/dvb-frontends/m88ds3103.c
+@@ -827,6 +827,7 @@ static int m88ds3103_get_frontend(struct dvb_frontend *fe,
+ 		}
+ 
+ 		c->modulation = QPSK;
++		c->rolloff = ROLLOFF_35;
+ 
+ 		break;
+ 	case SYS_DVBS2:
+@@ -1336,7 +1336,7 @@ static const struct dvb_frontend_ops m88ds3103_ops = {
+ 		.frequency_min =  950000,
+ 		.frequency_max = 2150000,
+ 		.frequency_tolerance = 5000,
+-		.symbol_rate_min =  1000000,
++		.symbol_rate_min =  100000,
+ 		.symbol_rate_max = 45000000,
+ 		.caps = FE_CAN_INVERSION_AUTO |
+ 			FE_CAN_FEC_1_2 |


### PR DESCRIPTION
To address this issue:
https://discourse.osmc.tv/t/geniatech-hdstar-v3-dvb-s2-not-working/12758

Pull in the changesets from https://bitbucket.org/updatelee/v4l-updatelee to make this adapter work.

> 
> 55c63982a513c93bdd42034f3353395c3cc4b4f8 (Bill Murphy, CrazyCat) [PATCH] [media] dw2102: Combine SU3000 (and OEM) support.
>  Thanks crazycat. fixes Geniatech SU3000 v3.0 hardware, by providing a method to
>  detect Montage ds3000 or m88ds3103 demod. Then attaching the proper demod
>  module. SU3000 v3.0 hardware has ts2022/m88ds3103 chips on board and the
>  ds3000 module previously wasn't working with this hardware. We now attach the
>  proper m88ds3103 demod for rev3, and ds3000 for the older versions.
> 
> Part of:
> 646903c536513c83b1775218676dcad6065abe73 (Bill Murphy, DarkSky)  [PATCH] [media] dw2102: Re-Apply commit 55c639
> 
> 1f91c1c49ef57425a66b481b70cf2d0e8ea0cc20 (Bill Murphy) [PATCH] m88ds3103 can tune SR with less then 1Msps,
>  so lets lower it to 100Ksps
> 
> 42f41610f1603c2497343d561e71784b88d66ace (Chris Lee) [media] m88ds3103: set dvb-s ROLLOFF_35
>  Was reporting wrong rolloff for dvb-s. dvb-s2 is OK.
> 
> Also apply relevant line of:
> 6d741bfed5ed06ed42a16d30f1ed7afdcaf7f092 (Sean Young) [PATCH] media: rc: rename RC_TYPE_* to RC_PROTO_* and RC_BIT_* to RC_PROTO_BIT_*
>  RC_TYPE is confusing and it's just the protocol. So rename it.