### PR TITLE
Fixed exception with MyOSMC

### DIFF
--- a/package/mediacenter-addon-osmc/src/script.module.osmcsetting.networking/resources/lib/networking_gui.py
+++ b/package/mediacenter-addon-osmc/src/script.module.osmcsetting.networking/resources/lib/networking_gui.py
@@ -757,6 +757,9 @@ class networking_gui(xbmcgui.WindowXMLDialog):
             if 'videolibrary' not in sub_dict:
                 sub_dict['videolibrary'] = {}
 
+            if sub_dict['videolibrary'] is None:
+                sub_dict['videolibrary'] = {}
+
             if self.getControl(MYSQL_IMPORT_WATCHED).isSelected():
                 sub_dict['videolibrary']['importwatchedstate'] = 'true'
 


### PR DESCRIPTION
If advancedsettings had empty videolibrary tags, MyOSMC raises and exception and does not save the user information.