### PR TITLE
[package][mediacenter-osmc]Add bitdepth to hints

### DIFF
--- a/package/mediacenter-osmc/patches/vero3-128-add-bitdepth-to-hints.patch
+++ b/package/mediacenter-osmc/patches/vero3-128-add-bitdepth-to-hints.patch
@@ -1,0 +1,193 @@
+From b575dac1e5d21e2750d508353131cfab237c2184 Mon Sep 17 00:00:00 2001
+From: Graham Horner <graham@hornercs.co.uk>
+Date: Wed, 24 Oct 2018 13:25:39 +0100
+Subject: [PATCH] Add bitdepth to hints
+
+---
+ .../cores/VideoPlayer/DVDCodecs/Video/AMLCodec.cpp |   4 +-
+ .../VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp     | 131 +++++++++++----------
+ 2 files changed, 73 insertions(+), 62 deletions(-)
+
+diff --git a/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.cpp b/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.cpp
+index 9cbb00f..4bc61e1 100644
+--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.cpp
++++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.cpp
+@@ -1664,8 +1664,8 @@ bool CAMLCodec::OpenDecoder(CDVDStreamInfo &hints)
+   CLog::Log(LOGDEBUG, "CAMLCodec::OpenDecoder "
+     "hints.width(%d), hints.height(%d), hints.codec(%d), hints.codec_tag(%d)",
+     hints.width, hints.height, hints.codec, hints.codec_tag);
+-  CLog::Log(LOGDEBUG, "CAMLCodec::OpenDecoder hints.fpsrate(%d), hints.fpsscale(%d), video_rate(%d)",
+-    hints.fpsrate, hints.fpsscale, am_private->video_rate);
++  CLog::Log(LOGDEBUG, "CAMLCodec::OpenDecoder hints.fpsrate(%d), hints.fpsscale(%d), video_rate(%d), hints.bitsperpixel(%d)",
++    hints.fpsrate, hints.fpsscale, am_private->video_rate, hints.bitsperpixel);
+   CLog::Log(LOGDEBUG, "CAMLCodec::OpenDecoder hints.aspect(%f), video_ratio.num(%d), video_ratio.den(%d)",
+     hints.aspect, video_ratio.num, video_ratio.den);
+   CLog::Log(LOGDEBUG, "CAMLCodec::OpenDecoder hints.orientation(%d), hints.forced_aspect(%d), hints.extrasize(%d)",
+diff --git a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+index 4eed32a..381feef 100644
+--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
++++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+@@ -57,6 +57,7 @@
+ extern "C" {
+ #include "libavutil/dict.h"
+ #include "libavutil/opt.h"
++#include "libavutil/pixdesc.h"
+ }
+ 
+ 
+@@ -1340,74 +1341,84 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
+ 
+     switch (pStream->codec->codec_type)
+     {
+-    case AVMEDIA_TYPE_AUDIO:
+-      {
+-        CDemuxStreamAudioFFmpeg* st = new CDemuxStreamAudioFFmpeg(this, pStream);
+-        stream = st;
+-        st->iChannels = pStream->codec->channels;
+-        st->iSampleRate = pStream->codec->sample_rate;
+-        st->iBlockAlign = pStream->codec->block_align;
+-        st->iBitRate = pStream->codec->bit_rate;
+-        st->iBitsPerSample = pStream->codec->bits_per_raw_sample;
+-        st->iChannelLayout = pStream->codec->channel_layout;
+-        if (st->iBitsPerSample == 0)
+-          st->iBitsPerSample = pStream->codec->bits_per_coded_sample;
+-  
+-        if(av_dict_get(pStream->metadata, "title", NULL, 0))
+-          st->m_description = av_dict_get(pStream->metadata, "title", NULL, 0)->value;
++      case AVMEDIA_TYPE_AUDIO:
++        {
++          CDemuxStreamAudioFFmpeg* st = new CDemuxStreamAudioFFmpeg(this, pStream);
++          stream = st;
++          st->iChannels = pStream->codec->channels;
++          st->iSampleRate = pStream->codec->sample_rate;
++          st->iBlockAlign = pStream->codec->block_align;
++          st->iBitRate = pStream->codec->bit_rate;
++          st->iBitsPerSample = pStream->codec->bits_per_raw_sample;
++          st->iChannelLayout = pStream->codec->channel_layout;
++          if (st->iBitsPerSample == 0)
++            st->iBitsPerSample = pStream->codec->bits_per_coded_sample;
+ 
+-        break;
+-      }
+-    case AVMEDIA_TYPE_VIDEO:
+-      {
+-        CDemuxStreamVideoFFmpeg* st = new CDemuxStreamVideoFFmpeg(this, pStream);
+-        stream = st;
+-        if(strcmp(m_pFormatContext->iformat->name, "flv") == 0)
+-          st->bVFR = true;
+-        else
+-          st->bVFR = false;
++          if(av_dict_get(pStream->metadata, "title", NULL, 0))
++            st->m_description = av_dict_get(pStream->metadata, "title", NULL, 0)->value;
+ 
+-        // never trust pts in avi files with h264.
+-        if (m_bAVI && pStream->codec->codec_id == AV_CODEC_ID_H264)
+-          st->bPTSInvalid = true;
++          break;
++        }
++      case AVMEDIA_TYPE_VIDEO:
++        {
++          CDemuxStreamVideoFFmpeg* st = new CDemuxStreamVideoFFmpeg(this, pStream);
++          stream = st;
++          if(strcmp(m_pFormatContext->iformat->name, "flv") == 0)
++            st->bVFR = true;
++          else
++            st->bVFR = false;
++
++          // never trust pts in avi files with h264.
++          if (m_bAVI && pStream->codec->codec_id == AV_CODEC_ID_H264)
++            st->bPTSInvalid = true;
+ 
+ #if defined(AVFORMAT_HAS_STREAM_GET_R_FRAME_RATE)
+-        AVRational r_frame_rate = av_stream_get_r_frame_rate(pStream);
++          AVRational r_frame_rate = av_stream_get_r_frame_rate(pStream);
+ #else
+-        AVRational r_frame_rate = pStream->r_frame_rate;
++          AVRational r_frame_rate = pStream->r_frame_rate;
+ #endif
+ 
+-        //average fps is more accurate for mkv files
+-        if (m_bMatroska && pStream->avg_frame_rate.den && pStream->avg_frame_rate.num)
+-        {
+-          st->iFpsRate = pStream->avg_frame_rate.num;
+-          st->iFpsScale = pStream->avg_frame_rate.den;
+-        }
+-        else if(r_frame_rate.den && r_frame_rate.num)
+-        {
+-          st->iFpsRate = r_frame_rate.num;
+-          st->iFpsScale = r_frame_rate.den;
+-        }
+-        else
+-        {
+-          st->iFpsRate  = 0;
+-          st->iFpsScale = 0;
+-        }
++          //average fps is more accurate for mkv files
++          if (m_bMatroska && pStream->avg_frame_rate.den && pStream->avg_frame_rate.num)
++          {
++            st->iFpsRate = pStream->avg_frame_rate.num;
++            st->iFpsScale = pStream->avg_frame_rate.den;
++          }
++          else if(r_frame_rate.den && r_frame_rate.num)
++          {
++            st->iFpsRate = r_frame_rate.num;
++            st->iFpsScale = r_frame_rate.den;
++          }
++          else
++          {
++            st->iFpsRate  = 0;
++            st->iFpsScale = 0;
++          }
+ 
+-        if (pStream->codec_info_nb_frames > 0 &&
+-            pStream->codec_info_nb_frames <= 2 &&
+-            m_pInput->IsStreamType(DVDSTREAM_TYPE_DVD))
+-        {
+-          CLog::Log(LOGDEBUG, "%s - fps may be unreliable since ffmpeg decoded only %d frame(s)", __FUNCTION__, pStream->codec_info_nb_frames);
+-          st->iFpsRate  = 0;
+-          st->iFpsScale = 0;
+-        }
++          if (pStream->codec_info_nb_frames > 0 &&
++              pStream->codec_info_nb_frames <= 2 &&
++              m_pInput->IsStreamType(DVDSTREAM_TYPE_DVD))
++          {
++            CLog::Log(LOGDEBUG, "%s - fps may be unreliable since ffmpeg decoded only %d frame(s)", __FUNCTION__, pStream->codec_info_nb_frames);
++            st->iFpsRate  = 0;
++            st->iFpsScale = 0;
++          }
++
++          st->iWidth = pStream->codec->width;
++          st->iHeight = pStream->codec->height;
++          st->fAspect = SelectAspect(pStream, st->bForcedAspect) * pStream->codec->width / pStream->codec->height;
++          st->iOrientation = 0;
++          st->iBitsPerPixel = pStream->codec->bits_per_raw_sample;
++          if (st->iBitsPerPixel == 0){
++            if (pStream->codec->color_trc == AVCOL_TRC_BT2020_12)
++              st->iBitsPerPixel = 12;
++            else if (pStream->codec->color_trc >= AVCOL_TRC_BT2020_10)
++              /* assume all 10-bit until 12-bit gets common */
++              st->iBitsPerPixel = 10;
++            else
++              st->iBitsPerPixel = 8;
++          }
+ 
+-        st->iWidth = pStream->codec->width;
+-        st->iHeight = pStream->codec->height;
+-        st->fAspect = SelectAspect(pStream, st->bForcedAspect) * pStream->codec->width / pStream->codec->height;
+-        st->iOrientation = 0;
+-        st->iBitsPerPixel = pStream->codec->bits_per_coded_sample;
+ 	if (pStream->codec->color_primaries == 9 || pStream->codec->color_primaries == 14 || pStream->codec->color_primaries == 15)
+ 	{
+ 	  CLog::Log(LOGDEBUG, "This is BT2020 content");
+@@ -1421,7 +1432,7 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
+         // detect stereoscopic mode
+         std::string stereoMode = GetStereoModeFromMetadata(pStream->metadata);
+           // check for metadata in file if detection in stream failed
+-        if (stereoMode.empty())
++          if (stereoMode.empty())
+           stereoMode = GetStereoModeFromMetadata(m_pFormatContext->metadata);
+         if (!stereoMode.empty())
+           st->stereo_mode = stereoMode;
+-- 
+2.11.0
+


### PR DESCRIPTION
This does very little but opened a code formatting can of worms in DVDDemuxFFmpeg.