### PR TITLE
[installer][target] Allow uncompressed tar for filesystem

### DIFF
--- a/installer/target/qt_target/qt_target_installer/extractworker.cpp
+++ b/installer/target/qt_target/qt_target_installer/extractworker.cpp
@@ -21,7 +21,7 @@ void ExtractWorker::extract()
     process = new QProcess();
     connect(process, SIGNAL(readyReadStandardOutput()), this, SLOT(readFromStdOut()));
     connect(process, SIGNAL(readyReadStandardError()), this, SLOT(readFromStdErr()));
-    process->start("/bin/sh -c \"/usr/bin/pv -n " + sourceName + " | tar xJf - -C " + destName + "\"");
+    process->start("/bin/sh -c \"/usr/bin/pv -n " + sourceName + " | tar xaf - -C " + destName + "\"");
     process->waitForFinished(-1);
     if (process->exitCode() != 0)
     {

--- a/installer/target/qt_target/qt_target_installer/mainwindow.cpp
+++ b/installer/target/qt_target/qt_target_installer/mainwindow.cpp
@@ -104,12 +104,16 @@ void MainWindow::install()
         haltInstall("could not mount bootfs");
         return;
     }
-    /* Sanity check: need filesystem.tar.xz */
+    /* Sanity check: need filesystem.tar.xz or filesystem.tar */
     QFile fileSystem(QString(MNT_BOOT) + "/filesystem.tar.xz");
     if (! fileSystem.exists())
     {
-        haltInstall("no filesystem found");
-        return;
+        QFile fileSystem(QString(MNT_BOOT) + "/filesystem.tar");
+        if (! fileSystem.exists())
+        {
+            haltInstall("no filesystem found");
+            return;
+        }
     }
     /* Load in preseeded values */
     preseed = new PreseedParser();


### PR DESCRIPTION
This allows to restore the filesystem from an uncompressed tarball.  Packing/unpacking is 8x faster than compressing it with xz.

Tested the -a switch works with filesystem.tar and filesystem.tar.xz.  Not built and tested.