### PR TITLE
[package][mediacenter-osmc] Add support for bluealsa

### DIFF
--- a/package/mediacenter-osmc/patches/all-122-add-support-for-bluealsa.patch
+++ b/package/mediacenter-osmc/patches/all-122-add-support-for-bluealsa.patch
@@ -1,0 +1,127 @@
+From 35bef3aad7a49ea985282848df34abfbfe7a3e8a Mon Sep 17 00:00:00 2001
+From: Graham Horner <graham@hornercs.co.uk>
+Date: Thu, 13 Feb 2020 14:14:19 +0000
+Subject: [PATCH] Add support for bluealsa
+
+Adds bluetooth to ALSADeviceMonitor and provides for BT device to be
+recognised from asoundrc.
+The correct way is to probe dbus for BT audio devices
+but using ALSA alone, this is the most user-friendly way to provide
+for multiple BT sinks pending a solution using dbus.
+---
+ xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp   | 25 ++++++++++++++++++-
+ .../Sinks/alsa/ALSADeviceMonitor.cpp          | 14 ++++++++++-
+ 2 files changed, 37 insertions(+), 2 deletions(-)
+
+diff --git a/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp b/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
+index 14117da18c..c92af20c2f 100644
+--- a/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
++++ b/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
+@@ -505,7 +505,7 @@ bool CAESinkALSA::Initialize(AEAudioFormat &format, std::string &device)
+   inconfig.format = format.m_dataFormat;
+   inconfig.sampleRate = format.m_sampleRate;
+ 
+-    CLog::Log(LOGINFO, "CAESinkALSA::Initialize - Requested layout: %s", std::string(format.m_channelLayout).c_str());
++  CLog::Log(LOGINFO, "CAESinkALSA::Initialize - Requested layout: %s", std::string(format.m_channelLayout).c_str());
+ 
+   /*
+    * We can't use the better GetChannelLayout() at this point as the device
+@@ -624,6 +624,7 @@ bool CAESinkALSA::Initialize(AEAudioFormat &format, std::string &device)
+   if (!InitializeHW(inconfig, outconfig) || !InitializeSW(outconfig))
+   {
+     free(selectedChmap);
++    CLog::Log(LOGINFO, "CAESinkALSA::Initialize - problem with HW or SW aborting");
+     return false;
+   }
+ 
+@@ -651,6 +652,7 @@ bool CAESinkALSA::Initialize(AEAudioFormat &format, std::string &device)
+     /* failure is OK, that likely just means the selected chmap is fixed already */
+     snd_pcm_set_chmap(m_pcm, selectedChmap);
+     free(selectedChmap);
++    CLog::Log(LOGINFO, "CAESinkALSA::Initialize - setting speaker layout %u", speaker_layout);
+   }
+   else
+   {
+@@ -948,6 +950,7 @@ bool CAESinkALSA::InitializeSW(const ALSAConfig &inconfig)
+     CLog::Log(LOGERROR, "CAESinkALSA::InitializeSW - Failed to set the parameters");
+     return false;
+   }
++  CLog::Log(LOGINFO, "CAESinkALSA::InitializeSW - success!");
+ 
+   return true;
+ }
+@@ -1236,6 +1239,24 @@ void CAESinkALSA::EnumerateDevicesEx(AEDeviceInfoList &list, bool force)
+     char *io = snd_device_name_get_hint(*hint, "IOID");
+     char *name = snd_device_name_get_hint(*hint, "NAME");
+     char *desc = snd_device_name_get_hint(*hint, "DESC");
++
++    /* handle BT devices defined in asoundrc
++     * TODO: read devices from dbus in a separate loop
++     */
++    std::string device;
++    device.assign(name);
++    if (device.find("bluealsa") != std::string::npos)
++    {
++      if (device.find("bluealsa_") != std::string::npos)
++      {
++        StringUtils::Replace(device, '_', ':');
++        strcpy(name, device.c_str());
++      }
++      else
++        CLog::Log(LOGINFO, "CAESinkALSA - bad device name for bluealsa %s\n \
++Use pcm.bluealsa_XX_XX_XX_XX_XX_XX_XX in asoundrc", device.c_str());
++    }
++
+     if ((!io || strcmp(io, "Output") == 0) && name
+         && strcmp(name, "null") != 0)
+     {
+@@ -1441,6 +1463,7 @@ void CAESinkALSA::EnumerateDevice(AEDeviceInfoList &list, const std::string &dev
+   if (!OpenPCMDevice(device, "", ALSA_MAX_CHANNELS, &pcmhandle, config))
+     return;
+ 
++  CLog::Log(LOGINFO, "CAESinkALSA::EnumerateDevice - device %s description %s", device.c_str(), description.c_str());
+   snd_pcm_info_t *pcminfo;
+   snd_pcm_info_alloca(&pcminfo);
+   memset(pcminfo, 0, snd_pcm_info_sizeof());
+diff --git a/xbmc/cores/AudioEngine/Sinks/alsa/ALSADeviceMonitor.cpp b/xbmc/cores/AudioEngine/Sinks/alsa/ALSADeviceMonitor.cpp
+index 7cdbc86bca..1ec7a98b60 100644
+--- a/xbmc/cores/AudioEngine/Sinks/alsa/ALSADeviceMonitor.cpp
++++ b/xbmc/cores/AudioEngine/Sinks/alsa/ALSADeviceMonitor.cpp
+@@ -52,6 +52,13 @@ void CALSADeviceMonitor::Start()
+       goto err_unref_monitor;
+     }
+ 
++    err = udev_monitor_filter_add_match_subsystem_devtype(m_udevMonitor, "bluetooth", NULL);
++    if (err)
++    {
++      CLog::Log(LOGERROR, "CALSADeviceMonitor::Start - udev_monitor_filter_add_match_subsystem_devtype() for bluetooth failed");
++      goto err_unref_monitor;
++    }
++
+     err = udev_monitor_enable_receiving(m_udevMonitor);
+     if (err)
+     {
+@@ -99,7 +106,7 @@ void CALSADeviceMonitor::FDEventCallback(int id, int fd, short revents, void *da
+     const char* action = udev_device_get_action(device);
+     const char* soundInitialized = udev_device_get_property_value(device, "SOUND_INITIALIZED");
+ 
+-    if (!action || !soundInitialized)
++    if (!action || (!soundInitialized && strcmp(udev_device_get_subsystem(device),"sound") == 0))
+       continue;
+ 
+     /* cardX devices emit a "change" event when ready (i.e. all subdevices added) */
+@@ -108,6 +115,11 @@ void CALSADeviceMonitor::FDEventCallback(int id, int fd, short revents, void *da
+       CLog::Log(LOGDEBUG, "CALSADeviceMonitor - ALSA card added (\"%s\", \"%s\")", udev_device_get_syspath(device), udev_device_get_devpath(device));
+       audioDevicesChanged = true;
+     }
++    else if (strcmp(action, "add") == 0 && strcmp(udev_device_get_subsystem(device),"bluetooth") == 0)
++    {
++      usleep(2000 * 1000); // really need to probe dbus here
++      audioDevicesChanged = true;
++    }
+     else if (strcmp(action, "remove") == 0)
+     {
+       CLog::Log(LOGDEBUG, "CALSADeviceMonitor - ALSA card removed");
+-- 
+2.17.1
+


### PR DESCRIPTION
Provides for each BT audio device to be enumerated and appear in audio settings.
Currently needs a list of devices in .asoundrc.
Tested on Vero4k+ only but should be OK on other devices.