### PR TITLE
Update settings.xml, defaults should select all logs and configs

### DIFF
--- a/package/mediacenter-addon-osmc/src/script.module.osmcsetting.logging/resources/settings.xml
+++ b/package/mediacenter-addon-osmc/src/script.module.osmcsetting.logging/resources/settings.xml
@@ -4,7 +4,7 @@
 		<setting action="RunScript($CWD/resources/lib/grablogs.py, upload)" id="5" label="32012" option="close" type="action"/>
 		<setting action="RunScript($CWD/resources/lib/grablogs.py, copy)"   id="6" label="32038" option="close" type="action"/>
 		<setting type="sep"/>
-		<setting default="false" id="all" label="32002" type="bool"/>
+		<setting default="true" id="all" label="32002" type="bool"/>
 		<setting type="sep"/>
 		<setting default="false" id="uname" label="32031" type="bool" visible="eq(-2,false)"/>
 		<setting default="false" id="dmesg" label="32041" type="bool" visible="eq(-3,false)"/>


### PR DESCRIPTION
Current defaults setting for label 32002 deselects all configs and logs which is obviously wrong.