### PR TITLE
[package] [mediacenter-addon-osmc] convert `call` to `check_call`

### DIFF
--- a/package/mediacenter-addon-osmc/src/script.module.osmcsetting.networking/resources/lib/osmc_advset_editor.py
+++ b/package/mediacenter-addon-osmc/src/script.module.osmcsetting.networking/resources/lib/osmc_advset_editor.py
@@ -138,9 +138,9 @@ class AdvancedSettingsEditor(object):
 
 			self.log('Empty dictionary passed to advancedsettings file writer. Preventing write, backing up and removing file.')
 
-			subprocess.call(['sudo', 'cp', loc, loc.replace('advancedsettings.xml', 'advancedsettings_backup.xml')])
+			subprocess.check_call(['sudo', 'cp', loc, loc.replace('advancedsettings.xml', 'advancedsettings_backup.xml')])
 
-			subprocess.call(['sudo', 'rm', '-f', loc])
+			subprocess.check_call(['sudo', 'rm', '-f', loc])
 
 			return
 

--- a/package/mediacenter-addon-osmc/src/script.module.osmcsetting.networking/resources/lib/osmc_systemd.py
+++ b/package/mediacenter-addon-osmc/src/script.module.osmcsetting.networking/resources/lib/osmc_systemd.py
@@ -37,7 +37,7 @@ def is_service_active(service_name):
 
 def update_service(service_name, service_status):
     fnull = open(os.devnull, 'w')
-    subprocess.call(['sudo', '/bin/systemctl', service_status, service_name], stderr=fnull, stdout=fnull)
+    subprocess.check_call(['sudo', '/bin/systemctl', service_status, service_name], stderr=fnull, stdout=fnull)
     fnull.close()
     time.sleep(1)
 

--- a/package/mediacenter-addon-osmc/src/script.module.osmcsetting.pi/resources/lib/OSMC_REparser.py
+++ b/package/mediacenter-addon-osmc/src/script.module.osmcsetting.pi/resources/lib/OSMC_REparser.py
@@ -1157,4 +1157,4 @@ if __name__ == "__main__":
     extracted_settings = config_to_kodi(MASTER_SETTINGS, config)
     new_settings = kodi_to_config(MASTER_SETTINGS, original_config, extracted_settings)
     write_config_file('/var/tmp/config.txt', new_settings)
-    subprocess.call(["sudo", "mv",  '/var/tmp/config.txt', '/boot/config.txt'])
+    subprocess.check_call(["sudo", "mv",  '/var/tmp/config.txt', '/boot/config.txt'])

--- a/package/mediacenter-addon-osmc/src/script.module.osmcsetting.pi/resources/lib/config_editor.py
+++ b/package/mediacenter-addon-osmc/src/script.module.osmcsetting.pi/resources/lib/config_editor.py
@@ -143,15 +143,15 @@ class ConfigEditor(xbmcgui.WindowXMLDialog):
 
 					# backup existing config
 					suffix = '_' + str(time.time()).split('.')[0]
-					subprocess.call(["sudo", "cp", self.config, '/home/pi/' ])
-					subprocess.call(["sudo", "mv", '/home/pi/config.txt', '/home/pi/config' + suffix + '.txt' ])
+					subprocess.check_call(["sudo", "cp", self.config, '/home/pi/' ])
+					subprocess.check_call(["sudo", "mv", '/home/pi/config.txt', '/home/pi/config' + suffix + '.txt' ])
 
 					# copy over the temp config.txt to /boot/ as superuser
-					subprocess.call(["sudo", "mv", tmp_loc, self.config ])
+					subprocess.check_call(["sudo", "mv", tmp_loc, self.config ])
 
 					# THIS IS JUST FOR TESTING, LAPTOP DOESNT LIKE SUDO HERE
 					try:
-						subprocess.call(["mv", tmp_loc, self.config ])
+						subprocess.check_call(["mv", tmp_loc, self.config ])
 					except:
 						pass
 

--- a/package/mediacenter-addon-osmc/src/script.module.osmcsetting.pi/resources/osmc/OSMCSetting.py
+++ b/package/mediacenter-addon-osmc/src/script.module.osmcsetting.pi/resources/osmc/OSMCSetting.py
@@ -234,7 +234,7 @@ Overclock settings are set using the Pi Overclock module."""
 		parser.write_config_file('/var/tmp/config.txt', new_settings)
 
 		# copy over the temp config.txt to /boot/ as superuser
-		subprocess.call(["sudo", "mv",  '/var/tmp/config.txt', self.config_location])
+		subprocess.check_call(["sudo", "mv",  '/var/tmp/config.txt', self.config_location])
 
 		ok = DIALOG.notification(lang(32095), lang(32096))
 
@@ -294,7 +294,7 @@ Overclock settings are set using the Pi Overclock module."""
 		parser.write_config_file('/var/tmp/config.txt', new_config)
 
 		# copy over the temp config.txt to /boot/ as superuser
-		subprocess.call(["sudo", "mv",  '/var/tmp/config.txt', self.config_location])
+		subprocess.check_call(["sudo", "mv",  '/var/tmp/config.txt', self.config_location])
 
 
 if __name__ == "__main__":

--- a/package/mediacenter-addon-osmc/src/script.module.osmcsetting.remotes/resources/lib/remote_gui.py
+++ b/package/mediacenter-addon-osmc/src/script.module.osmcsetting.remotes/resources/lib/remote_gui.py
@@ -242,7 +242,7 @@ class remote_GUI(xbmcgui.WindowXMLDialog):
 			with open('/var/tmp/blacklist-rc6.conf', 'w') as f:
 				f.write('blacklist ir_rc6_decoder\ninstall ir_rc6_decoder /bin/true')
 
-			subprocess.call(["sudo", "mv", '/var/tmp/blacklist-rc6.conf', self.rc6_file_loc])
+			subprocess.check_call(["sudo", "mv", '/var/tmp/blacklist-rc6.conf', self.rc6_file_loc])
 
 			log('RC6 blacklist file moved')
 
@@ -250,7 +250,7 @@ class remote_GUI(xbmcgui.WindowXMLDialog):
 
 			log('RC6 blacklist file removed')
 
-			subprocess.call(["sudo", "rm", "-f", self.rc6_file])
+			subprocess.check_call(["sudo", "rm", "-f", self.rc6_file])
 
 
 	def onClick(self, controlID):
@@ -357,7 +357,7 @@ class remote_GUI(xbmcgui.WindowXMLDialog):
 			log('Original lircd_path target: %s' % original_target)
 			
 			# symlink the master conf to the new selection
-			subprocess.call(['sudo', 'ln', '-sf', self.remote_selection, LIRCD_PATH])
+			subprocess.check_call(['sudo', 'ln', '-sf', self.remote_selection, LIRCD_PATH])
 
 
 			# open test dialog
@@ -370,9 +370,9 @@ class remote_GUI(xbmcgui.WindowXMLDialog):
 			# if the test wasnt successful, then revert to the previous conf
 			if not self.remote_test.test_successful:
 
-				subprocess.call(['sudo', 'ln', '-sf', original_target, LIRCD_PATH])
+				subprocess.check_call(['sudo', 'ln', '-sf', original_target, LIRCD_PATH])
 
-				subprocess.call(['sudo', 'systemctl', 'restart', 'lircd_helper@*'])
+				subprocess.check_call(['sudo', 'systemctl', 'restart', 'lircd_helper@*'])
 
 				# add busy dialog, loop until service restarts
 

--- a/package/mediacenter-addon-osmc/src/script.module.osmcsetting.updates/resources/lib/OSMC_Backups.py
+++ b/package/mediacenter-addon-osmc/src/script.module.osmcsetting.updates/resources/lib/OSMC_Backups.py
@@ -916,7 +916,7 @@ class osmc_backup(object):
 				f.writelines(uniquify(new_lines))
 
 			# finally, copy the temp fstab over the live fstab
-			res = subprocess.call(["sudo", "mv", '/tmp/fstab', '/etc/fstab' ])
+			res = subprocess.check_call(["sudo", "mv", '/tmp/fstab', '/etc/fstab' ])
 
 
 

--- a/package/mediacenter-addon-osmc/src/script.module.osmcsetting.updates/resources/osmc/OSMCSetting.py
+++ b/package/mediacenter-addon-osmc/src/script.module.osmcsetting.updates/resources/osmc/OSMCSetting.py
@@ -210,9 +210,9 @@ class OSMCSettingClass(threading.Thread):
 		# check the kodi reset setting, if it is true then create the kodi_reset file, otherwise remove that file	
 		if addon.getSetting('kodi_reset') == 'true':
 			log('creating kodi reset file')
-			subprocess.call(['sudo', 'touch', self.reset_file])
+			subprocess.check_call(['sudo', 'touch', self.reset_file])
 		else:
-			subprocess.call(['sudo', 'rm', self.reset_file])
+			subprocess.check_call(['sudo', 'rm', self.reset_file])
 
 		log('END')
 		for x, k in self.setting_data_method.iteritems():

--- a/package/mediacenter-addon-osmc/src/service.osmc.settings/resources/lib/osmc_main.py
+++ b/package/mediacenter-addon-osmc/src/service.osmc.settings/resources/lib/osmc_main.py
@@ -212,7 +212,7 @@ class Main(object):
 							log('/tmp/walkthrough_completed written')
 							pass
 							
-						subprocess.call(['sudo', 'mv', '/tmp/walkthrough_completed', '/walkthrough_completed'])
+						subprocess.check_call(['sudo', 'mv', '/tmp/walkthrough_completed', '/walkthrough_completed'])
 						try:
 							xbmc.setosmcwalkthroughstatus(2)
 						except Exception as e:


### PR DESCRIPTION
(Hi maintainers! I'm a happy osmc user, previously submitted #334)

I noticed several potential bugs around the use of `subprocess.call` which might silently fail to detect issues if permissions or filesystem problems exist.

The underlying issue is that `subprocess.call` returns the status code, but will do nothing if the status code is non-zero. The preferred idiom is to immediately check the return code if the operation is critical, or use `subprocess.check_call` which will raise an Exception on non-zero return codes.

I am a maintainer on an open-source project named [semgrep](https://semgrep.dev) (originally developed at Facebook) which helped me find this issue. Credit to https://github.com/returntocorp/semgrep-rules/blob/develop/python/smells/unchecked-returns.yaml for helping filter out the cases where the return value is in fact being checked. 