### PR TITLE
[package] [rbp-userland-osmc] Add depend for dtparam

### DIFF
--- a/package/rbp-userland-osmc/files-src/DEBIAN/control
+++ b/package/rbp-userland-osmc/files-src/DEBIAN/control
@@ -5,4 +5,5 @@ Essential: No
 Priority: required
 Architecture: armhf
 Maintainer: Sam G Nazarko <email@samnazarko.co.uk>
+Depends: device-tree-compiler
 Description: Raspberry Pi userland package with headers


### PR DESCRIPTION
dtparam command (aks dtoverlay) need `dtc` tool for generate base.dtb and load it, then to configure the base Raspberry Pi hardware. Add depend for avoid error `* Failed to read active DTB`.