### PR TITLE
[package][vero3-device-osmc] Disable alsa-state pending fix to alsa d…

### DIFF
--- a/package/vero3-device-osmc/files/etc/systemd/system/alsa-state.service
+++ b/package/vero3-device-osmc/files/etc/systemd/system/alsa-state.service
@@ -1,0 +1,1 @@
+/dev/null


### PR DESCRIPTION
…river

Alsa driver in 4.9 continues to cause issues with channel maps.
alsa-state.service needs disabling as it was with 3.14.