### PR TITLE
make check dependent from user name 'osmc', hash method, salt and hash found in /etc/shadow to compare with default osmc password

### DIFF
--- a/package/base-files-osmc/files/etc/profile.d/105-check-ssh-password.sh
+++ b/package/base-files-osmc/files/etc/profile.d/105-check-ssh-password.sh
@@ -5,10 +5,11 @@ pwd_hash_method=$(echo $shadow_entry|cut -d '$' -f 2)
 pwd_hash_salt=$(echo $shadow_entry|cut -d '$' -f 3)
 pwd_hash_rest=$(echo $shadow_entry|cut -d '$' -f 4)
 pwd_hash=$(echo $pwd_hash_rest|cut -d ':' -f 1)
-openssl_hash=$(echo $(openssl passwd -$pwd_hash_method -salt $pwd_hash_salt osmc)|cut -d '$' -f 4)
+openssl_hash=$(echo $(openssl passwd -$pwd_hash_method -salt $pwd_hash_salt $user)|cut -d '$' -f 4)
 if systemctl is-active ssh -q && [ "$pwd_hash" = "$openssl_hash" ] && [ ! -f /home/osmc/.nosshwarn ]
 then
-    echo "Warning: you are using SSH with the default OSMC credentials. This is a security risk!"
+    echo "Warning: You are using SSH with the default OSMC credentials."
+    echo "This is a security risk!"
     echo "To change your password, type passwd"
     echo "To disable this warning, type touch /home/osmc/.nosshwarn"
 fi

--- a/package/base-files-osmc/files/etc/profile.d/105-check-ssh-password.sh
+++ b/package/base-files-osmc/files/etc/profile.d/105-check-ssh-password.sh
@@ -1,6 +1,6 @@
 user=$(whoami)
 if [ "$user" != "osmc" ]; then return 0; fi
-if systemctl is-active ssh -q && sudo grep -q "osmc:\$1\$P.ZH6EFu\$L08/1ZYI6FdHu3aw0us.u0:17569:0:99999:7:::" /etc/shadow && [ ! -f /home/osmc/.nosshwarn ]
+if systemctl is-active ssh -q && sudo grep -q "osmc:\$1\$P.ZH6EFu\$L08/1ZYI6FdHu3aw0us.u0:" /etc/shadow && [ ! -f /home/osmc/.nosshwarn ]
 then
     echo "Warning: you are using SSH with the default OSMC credentials. This is a security risk."
     echo "To change your password, type passwd"

--- a/package/base-files-osmc/files/etc/profile.d/105-check-ssh-password.sh
+++ b/package/base-files-osmc/files/etc/profile.d/105-check-ssh-password.sh
@@ -1,8 +1,14 @@
 user=$(whoami)
 if [ "$user" != "osmc" ]; then return 0; fi
-if systemctl is-active ssh -q && sudo grep -q "osmc:\$1\$P.ZH6EFu\$L08/1ZYI6FdHu3aw0us.u0:" /etc/shadow && [ ! -f /home/osmc/.nosshwarn ]
+shadow_entry=$(sudo getent shadow osmc)
+pwd_hash_method=$(echo $shadow_entry|cut -d '$' -f 2)
+pwd_hash_salt=$(echo $shadow_entry|cut -d '$' -f 3)
+pwd_hash_rest=$(echo $shadow_entry|cut -d '$' -f 4)
+pwd_hash=$(echo $pwd_hash_rest|cut -d ':' -f 1)
+openssl_hash=$(echo $(openssl passwd -$pwd_hash_method -salt $pwd_hash_salt osmc)|cut -d '$' -f 4)
+if systemctl is-active ssh -q && [ "$pwd_hash" = "$openssl_hash" ] && [ ! -f /home/osmc/.nosshwarn ]
 then
-    echo "Warning: you are using SSH with the default OSMC credentials. This is a security risk."
+    echo "Warning: you are using SSH with the default OSMC credentials. This is a security risk!"
     echo "To change your password, type passwd"
     echo "To disable this warning, type touch /home/osmc/.nosshwarn"
 fi


### PR DESCRIPTION
Currently the check contains all information of a typical line in /etc/shadow means days of last password change since 1970, etc. This does not meet anymore the current osmc user and is unneccessary. Only user name and MD5+salt of the password should be tested.