### PR TITLE
[package][kernel-osmc] Improve splash rendering

### DIFF
--- a/package/kernel-osmc/initramfs-src/init.d/vero364
+++ b/package/kernel-osmc/initramfs-src/init.d/vero364
@@ -20,17 +20,21 @@ do
 esac
 done
 
-preferred=$(busybox grep \* /sys/class/amhdmitx/amhdmitx0/disp_cap | busybox sed 's/\*//g')
+preferred=$(busybox grep \1080.60hz /sys/class/amhdmitx/amhdmitx0/disp_cap | busybox sed 's/\*//g')
+if ! [ "$preferred" ]
+then
+	preferred=$(busybox grep \* /sys/class/amhdmitx/amhdmitx0/disp_cap | busybox sed 's/\*//g')
+fi
 if echo $hdmimode | busybox grep -q force
 then
     hdmimode=$(echo $hdmimode | /bin/busybox sed 's/force//g')
     echo "$hdmimode" > /sys/class/display/mode
 else
-if [ "$preferred" ] && [ "$hdmimode" != "$preferred" ]
-then
-  if ! echo $preferred | busybox grep -q 2160p; then hdmimode="$preferred"; fi
-  echo "$hdmimode" > /sys/class/display/mode
-fi
+	if [ "$preferred" ] && [ "$hdmimode" != "$preferred" ]
+	then
+	  if ! echo $preferred | busybox grep -q 2160p; then hdmimode="$preferred"; fi
+	fi
+	echo "$hdmimode" > /sys/class/display/mode
 fi
 
 # Configure framebuffer X and Y size


### PR DESCRIPTION
Use 1080p or 1080i if it exists so avoid scaling by ply-image for HD-Ready and 4K displays.
