### PR TITLE
find the settings that exist before setting them

### DIFF
--- a/package/perftune-osmc/files/usr/bin/performance_tuner
+++ b/package/perftune-osmc/files/usr/bin/performance_tuner
@@ -72,11 +72,12 @@ then
 	# 30 seconds of accelerated boot. we set curgov to ondemand so the next check only doesn't flip us back if we had performance to begin with
 	sleep 30
 	echo "ondemand" | tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor > /dev/null 2>&1 #all platforms
-	find /sys/devices/system/cpu/cpufreq -name ondemand | while read od ; do
-		(echo     50 > $od/up_threshold)
-		(echo 100000 > $od/sampling_rate)
-		(echo     50 > $od/sampling_down_factor)
-	done
+	ondemand=/sys/devices/system/cpu/cpufreq/policy0/ondemand
+	# the following line can be removed once 3.14 kernels are history
+	[ -d $ondemand ] || ondemand=/sys/devices/system/cpu/cpufreq/ondemand
+	(echo     50 > $ondemand/up_threshold)
+	(echo 100000 > $ondemand/sampling_rate)
+	(echo     50 > $ondemand/sampling_down_factor)
 	else
 		echo "powersave" | tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor > /dev/null 2>&1
 fi

--- a/package/perftune-osmc/files/usr/bin/performance_tuner
+++ b/package/perftune-osmc/files/usr/bin/performance_tuner
@@ -72,12 +72,11 @@ then
 	# 30 seconds of accelerated boot. we set curgov to ondemand so the next check only doesn't flip us back if we had performance to begin with
 	sleep 30
 	echo "ondemand" | tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor > /dev/null 2>&1 #all platforms
-	(echo 50 > /sys/devices/system/cpu/cpufreq/ondemand/up_threshold) > /dev/null 2>&1
-	(echo 100000 > /sys/devices/system/cpu/cpufreq/ondemand/sampling_rate) > /dev/null 2>&1
-	(echo 50 > /sys/devices/system/cpu/cpufreq/ondemand/sampling_down_factor) > /dev/null 2>&1
-	(echo 50 > /sys/devices/system/cpu/cpufreq/policy0/ondemand/up_threshold) > /dev/null 2>&1
-	(echo 100000 > /sys/devices/system/cpu/cpufreq/policy0/ondemand/sampling_rate) > /dev/null 2>&1
-	(echo 50 > /sys/devices/system/cpu/cpufreq/policy0/ondemand/sampling_down_factor) > /dev/null 2>&1
+	find /sys/devices/system/cpu/cpufreq -name ondemand | while read od ; do
+		(echo     50 > $od/up_threshold)
+		(echo 100000 > $od/sampling_rate)
+		(echo     50 > $od/sampling_down_factor)
+	done
 	else
 		echo "powersave" | tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor > /dev/null 2>&1
 fi


### PR DESCRIPTION
This change is prompted by the fact that (on my Vero4k) the `/sys/devices/system/cpu/cpufreq/policy0` directory does not exist, with the result that the last echo fails which means that `performance_tuner` exits with an error code of 2 and then systemd is left thinking that `performance.service` is in a failed state, with this sort of thing in the journal:

> Nov 03 09:17:33 osmc systemd[1]: performance.service: Main process exited, code=exited, status=2/INVALIDARGUMENT
> Nov 03 09:17:33 osmc systemd[1]: performance.service: Failed with result 'exit-code'.

This change also reverts the discarding of output, because that was quite unhelpful when tracking this problem down, so my preference is to leave the echos with the ability to report errors.

BTW I'm not sure I see the reason behind running these echos in subshells, but since that's harmless, I left it.

I'm running this on a Vero4K, so I don't have the `../policy0/..` directory, so I'm not sure if that's meant to be a complete list or whether there's a ../policy1/.. say, that you want to leave untouched. If it is the case that there are other subdirectories that need to be left untouched, then I've done an [alternative fix](https://github.com/phil-hands/osmc/tree/perf-ondemand-list)

HTH

Cheers, Phil.