### PR TITLE
[package] [mediacenter-addon-osmc] resolve warning for use of deprecated method

### DIFF
--- a/package/mediacenter-addon-osmc/src/script.module.osmcsetting.apfstore/resources/lib/apfstore/apf_class.py
+++ b/package/mediacenter-addon-osmc/src/script.module.osmcsetting.apfstore/resources/lib/apfstore/apf_class.py
@@ -12,15 +12,15 @@ import hashlib
 import os
 from io import open
 
-import xbmc
 import xbmcaddon
 import xbmcgui
+import xbmcvfs
 from osmccommon.osmc_language import LangRetriever
 from osmccommon.osmc_logging import StandardLogger
 from osmccommon.osmc_logging import clog
 
 ADDON_ID = "script.module.osmcsetting.apfstore"
-ADDON_DATA = xbmc.translatePath('special://userdata/addon_data/%s/' % ADDON_ID)
+ADDON_DATA = xbmcvfs.translatePath('special://userdata/addon_data/%s/' % ADDON_ID)
 
 log = StandardLogger(ADDON_ID, os.path.basename(__file__)).log
 

--- a/package/mediacenter-addon-osmc/src/script.module.osmcsetting.apfstore/resources/lib/apfstore/apf_store.py
+++ b/package/mediacenter-addon-osmc/src/script.module.osmcsetting.apfstore/resources/lib/apfstore/apf_store.py
@@ -19,9 +19,9 @@ from io import open
 
 import requests
 
-import xbmc
 import xbmcaddon
 import xbmcgui
+import xbmcvfs
 from osmccommon.osmc_language import LangRetriever
 from osmccommon.osmc_logging import StandardLogger
 from osmccommon.osmc_logging import clog
@@ -57,7 +57,7 @@ APF JSON STRUCTURE
 """
 
 ADDON_ID = "script.module.osmcsetting.apfstore"
-ADDON_DATA = xbmc.translatePath('special://userdata/addon_data/%s/' % ADDON_ID)
+ADDON_DATA = xbmcvfs.translatePath('special://userdata/addon_data/%s/' % ADDON_ID)
 
 log = StandardLogger(ADDON_ID, os.path.basename(__file__)).log
 

--- a/package/mediacenter-addon-osmc/src/script.module.osmcsetting.networking/resources/lib/osmcnetworking/networking_gui.py
+++ b/package/mediacenter-addon-osmc/src/script.module.osmcsetting.networking/resources/lib/osmcnetworking/networking_gui.py
@@ -19,6 +19,7 @@ from io import open
 import xbmc
 import xbmcaddon
 import xbmcgui
+import xbmcvfs
 from osmccommon.osmc_language import LangRetriever
 from osmccommon.osmc_logging import StandardLogger
 
@@ -858,7 +859,7 @@ class NetworkingGui(xbmcgui.WindowXMLDialog):
                 # if the dictionary is empty, don't write anything
                 return
 
-        user_data = xbmc.translatePath("special://userdata")
+        user_data = xbmcvfs.translatePath("special://userdata")
         loc = os.path.join(user_data, 'advancedsettings.xml')
 
         try:

--- a/package/mediacenter-addon-osmc/src/script.module.osmcsetting.networking/resources/lib/osmcnetworking/osmc_advset_editor.py
+++ b/package/mediacenter-addon-osmc/src/script.module.osmcsetting.networking/resources/lib/osmcnetworking/osmc_advset_editor.py
@@ -13,7 +13,7 @@ import re
 import subprocess
 from io import open
 
-import xbmc
+import xbmcvfs
 import xmltodict as xmltodict
 
 
@@ -33,7 +33,7 @@ class AdvancedSettingsEditor(object):
         """
             Parses the advancedsettings.xml file. Returns a dict with ALL the details.
         """
-        user_data = xbmc.translatePath('special://userdata')
+        user_data = xbmcvfs.translatePath('special://userdata')
         loc = os.path.join(user_data, 'advancedsettings.xml')
 
         null_doc = {

--- a/package/mediacenter-addon-osmc/src/script.module.osmcsetting.updates/resources/lib/osmcupdates/osmc_backups.py
+++ b/package/mediacenter-addon-osmc/src/script.module.osmcsetting.updates/resources/lib/osmcupdates/osmc_backups.py
@@ -171,7 +171,7 @@ class OSMCBackup(object):
         """
             returns the location of the kodi folder
         """
-        return xbmc.translatePath('special://home')
+        return xbmcvfs.translatePath('special://home')
 
     def create_backup_file_list(self):
         """
@@ -213,7 +213,7 @@ class OSMCBackup(object):
 
         # check locally
         try:
-            st = os.statvfs(xbmc.translatePath('special://temp'))
+            st = os.statvfs(xbmcvfs.translatePath('special://temp'))
 
             requirement = self.estimate_disk_requirement()
             if st.f_frsize:
@@ -329,7 +329,7 @@ class OSMCBackup(object):
         # get the tag for the backup file
         tag = self.generate_tarball_name()
         # generate name for temporary tarball
-        local_tarball_name = os.path.join(xbmc.translatePath('special://temp'), FILE_PATTERN % tag)
+        local_tarball_name = os.path.join(xbmcvfs.translatePath('special://temp'), FILE_PATTERN % tag)
         # generate name for remote tarball
         remote_tarball_name = os.path.join(location, FILE_PATTERN % tag)
         # get the size of all the files that are being backed up
@@ -351,7 +351,7 @@ class OSMCBackup(object):
             'message': self.lang(32159)
         })
 
-        new_root = xbmc.translatePath('special://home')
+        new_root = xbmcvfs.translatePath('special://home')
 
         try:
             with tarfile.open(name=local_tarball_name, mode="w:gz") as tar:
@@ -489,7 +489,7 @@ class OSMCBackup(object):
 
                 # this requires copying the tar_file from its stored location, to kodi/temp
                 # xbmcvfs cannot read into tar files without copying the whole thing to memory
-                temp_copy = os.path.join(xbmc.translatePath('special://temp'), basename)
+                temp_copy = os.path.join(xbmcvfs.translatePath('special://temp'), basename)
 
                 result = xbmcvfs.copy(remote_file, temp_copy)
                 if not result:
@@ -583,7 +583,7 @@ class OSMCBackup(object):
                 if overwrite == 0:
                     # restore over existing files
                     log('User has chosen to overwrite existing files.')
-                    restore_location = xbmc.translatePath('special://home')
+                    restore_location = xbmcvfs.translatePath('special://home')
 
                     # check the restore_items for guisettings.xml, if found then restore that
                     # to the addon_data folder, create the /RESET_GUISETTINGS file and write

--- a/package/mediacenter-addon-osmc/src/script.module.osmcsetting.updates/resources/lib/osmcupdates/service_entry.py
+++ b/package/mediacenter-addon-osmc/src/script.module.osmcsetting.updates/resources/lib/osmcupdates/service_entry.py
@@ -24,6 +24,7 @@ import apt
 import xbmc
 import xbmcaddon
 import xbmcgui
+import xbmcvfs
 from osmccommon import osmc_comms
 from osmccommon.osmc_language import LangRetriever
 from osmccommon.osmc_logging import StandardLogger
@@ -263,8 +264,8 @@ class Main(object):
     @property
     def lib_path(self):
         if not self._lib_path:
-            self._lib_path = xbmc.translatePath(os.path.join(self.path, 'resources',
-                                                             'lib', 'osmcupdates'))
+            self._lib_path = xbmcvfs.translatePath(os.path.join(self.path, 'resources',
+                                                                'lib', 'osmcupdates'))
         return self._lib_path
 
     def _daemon(self):

--- a/package/mediacenter-addon-osmc/src/service.osmc.settings/resources/lib/osmcsettings/osmc_ubiquifonts.py
+++ b/package/mediacenter-addon-osmc/src/service.osmc.settings/resources/lib/osmcsettings/osmc_ubiquifonts.py
@@ -15,9 +15,9 @@ import traceback
 from io import open
 from xml.etree import ElementTree
 
-import xbmc
 import xbmcaddon
 import xbmcgui
+import xbmcvfs
 from osmccommon.osmc_logging import StandardLogger
 
 ADDON_ID = 'service.osmc.settings'
@@ -34,11 +34,11 @@ class UbiquiFonts:
         _logger = StandardLogger(addon_id, os.path.basename(__file__))
         self.log = _logger.log
 
-        self.resource_folder = xbmc.translatePath(
+        self.resource_folder = xbmcvfs.translatePath(
             os.path.join(addon.getAddonInfo('path'), 'resources')
         )
 
-        self.font_folder = xbmc.translatePath(
+        self.font_folder = xbmcvfs.translatePath(
             os.path.join(self.resource_folder, 'skins', 'Default', 'fonts')
         )
 
@@ -116,7 +116,7 @@ class UbiquiFonts:
         return os.path.join(skin_folder, folder)
 
     def import_osmc_fonts(self):
-        skin_folder = xbmc.translatePath('special://skin')
+        skin_folder = xbmcvfs.translatePath('special://skin')
 
         self.log('skin_folder: %s' % skin_folder)
 

--- a/package/mediacenter-addon-osmc/src/service.osmc.settings/resources/lib/osmcsettings/osmc_walkthru.py
+++ b/package/mediacenter-addon-osmc/src/service.osmc.settings/resources/lib/osmcsettings/osmc_walkthru.py
@@ -22,6 +22,7 @@ import requests
 import xbmc
 import xbmcaddon
 import xbmcgui
+import xbmcvfs
 from osmccommon.osmc_language import LangRetriever
 from osmccommon.osmc_logging import StandardLogger
 
@@ -249,8 +250,8 @@ class WalkthruGui(xbmcgui.WindowXMLDialog):
         self.selected_country = None
 
         # textures for the skin image
-        media_path = xbmc.translatePath(os.path.join(strFallbackPath, 'resources',
-                                                     'skins', 'Default', 'media'))
+        media_path = xbmcvfs.translatePath(os.path.join(strFallbackPath, 'resources',
+                                                        'skins', 'Default', 'media'))
         self.osmc_skin_image = os.path.join(media_path, 'osmc_preview.jpg')
         self.conf_skin_image = os.path.join(media_path, 'conf_preview.jpg')
 


### PR DESCRIPTION
WARNING <general>: xbmc.translatePath is deprecated and might be removed in future kodi versions. Please use xbmcvfs.translatePath instead.