### PR TITLE
[package] [mediacenter-addon-osmc] fix grab-logs GUI Settings (abridged)

### DIFF
--- a/package/mediacenter-addon-osmc/src/script.module.osmcsetting.logging/resources/lib/osmclogging/readgui.py
+++ b/package/mediacenter-addon-osmc/src/script.module.osmcsetting.logging/resources/lib/osmclogging/readgui.py
@@ -132,7 +132,8 @@ class GuiParser(object):
             if options is not None:
                 system_settings[_id]['options'] = {}
                 for o in options:
-                    system_settings[_id]['options'][o.text] = o.attrib['label']
+                    if 'label' in o.attrib:
+                        system_settings[_id]['options'][o.text] = o.attrib['label']
 
             default = setting.find('default')
             if default is not None:


### PR DESCRIPTION
Fixed grab-logs GUI Settings (abridged) Output:

====================== GUI Settings (abridged) =================== z9Z12KgS
Dolby Digital (AC3) capable receiver: true
Enable Dolby Digital (AC3) transcoding: false
Audio output device: ALSA:default
Number of channels: 3.1 ===> Default: 2.0
Output configuration: Best match
DTS-HD capable receiver: false
DTS capable receiver: true
Dolby Digital Plus (E-AC3) capable receiver: false
Play GUI sounds: Only when playback stopped
Allow passthrough: false
TrueHD capable receiver: false
Adjust display refresh rate: Off
Sync playback to display: false
Disable stereoscopic 3D mode when playback ended: true
Playback mode of stereoscopic 3D videos: Ask me
Display 4:3 videos as: Normal
Enable HQ scalers for scaling above: 20
Allow hardware acceleration - amcodec: true
Accelerate MPEG2: Always
Accelerate MPEG4: HD and up
Accelerate h264: Always
Force 422 colour subsampling: false
Force RGB output: false
Use limited colour range (16-235): true
Lock HDMI HPD: false
GUI Resolution: 1920x1080 @ 60p

---------------------- GUI Settings (abridged) END --------------- z9Z12KgS