### PR TITLE
[package][kernel-osmc] Add snd_aloop for Vero3

### DIFF
--- a/package/kernel-osmc/patches/vero364-000-add-kernel-config.patch
+++ b/package/kernel-osmc/patches/vero364-000-add-kernel-config.patch
@@ -1,6 +1,6 @@
 --- /dev/null	2021-04-07 14:42:52.310826383 +0100
 +++ b/.config	2021-04-16 03:06:54.154561889 +0100
-@@ -0,0 +1,6001 @@
+@@ -0,0 +1,6006 @@
 +#
 +# Automatically generated file; DO NOT EDIT.
 +# Linux/arm64 4.9.113 Kernel Configuration
@@ -3825,7 +3825,12 @@
 +# CONFIG_SND_OPL4_LIB_SEQ is not set
 +# CONFIG_SND_SBAWE_SEQ is not set
 +# CONFIG_SND_EMU10K1_SEQ is not set
-+# CONFIG_SND_DRIVERS is not set
++CONFIG_SND_DRIVERS=y
++# CONFIG_SND_DUMMY is not set
++CONFIG_SND_ALOOP=m
++# CONFIG_SND_MTPAV is not set
++# CONFIG_SND_SERIAL_U16550 is not set
++# CONFIG_SND_MPU401 is not set
 +# CONFIG_SND_PCI is not set
 +
 +#


### PR DESCRIPTION
Brings 4.9 kernel on Vero into line with 3.14 and RPi kernels