### PR TITLE
[package] [bluez-osmc] Enable Sixaxis (PS3 controller) plugin

### DIFF
--- a/package/bluez-osmc/build.sh
+++ b/package/bluez-osmc/build.sh
@@ -44,7 +44,7 @@ then
 	echo "Package: ${1}-bluez-osmc" >> files/DEBIAN/control
 	pushd src/bluez-$VERSION
     	install_patch "../../patches" "all"
-	./configure --prefix=/usr --sysconfdir=/etc --localstatedir=/var --with-udevdir=/lib/udev --with-systemdsystemunitdir=/lib/systemd/system --with-systemduserunitdir=/etc/systemd/user
+	./configure --prefix=/usr --sysconfdir=/etc --localstatedir=/var --with-udevdir=/lib/udev --with-systemdsystemunitdir=/lib/systemd/system --with-systemduserunitdir=/etc/systemd/user --enable-sixaxis
 	if [ $? != 0 ]; then echo -e "Configure failed!" && umount /proc/ > /dev/null 2>&1 && exit 1; fi
 	$BUILD
 	if [ $? != 0 ]; then echo -e "Build failed!" && exit 1; fi


### PR DESCRIPTION
This PR sets the `--enable-sixaxis` build flag on bluez so that PS3 controllers can be easily paired wirelessly with OSMC devices.