### PR TITLE
[package] [mediacenter-addon-osmc] fix bluetooth devices without Class not being listed

### DIFF
--- a/package/mediacenter-addon-osmc/src/script.module.osmcsetting.networking/resources/lib/osmcnetworking/osmc_bluetooth.py
+++ b/package/mediacenter-addon-osmc/src/script.module.osmcsetting.networking/resources/lib/osmcnetworking/osmc_bluetooth.py
@@ -185,7 +185,10 @@ class OSMCBluetooth:
                 dbus_dict = managed_objects[path][DEVICE_PATH]
                 device_dict = {}
 
-                if 'Class' not in dbus_dict:
+                if not dbus_dict.get('Name') or \
+                        (dbus_dict.get('Alias') and dbus_dict.get('Alias') in
+                         [dbus_dict.get('Address', ''),
+                          dbus_dict.get('Address', '').replace(':', '-')]):
                     continue
 
                 # remove dbus.String from the key


### PR DESCRIPTION
https://discourse.osmc.tv/t/testing-kodi-v19-builds-for-vero-4k-4k/89151/620