### PR TITLE
[package] [kernel-osmc] Provide wireguard-modules

### DIFF
--- a/package/kernel-osmc/files/DEBIAN/control
+++ b/package/kernel-osmc/files/DEBIAN/control
@@ -5,3 +5,4 @@ Essential: No
 Priority: required
 Maintainer: Sam G Nazarko <email@samnazarko.co.uk>
 Description: Kernel meta package bringing in the latest OSMC kernel for this device
+Provides: wireguard-modules (= 1.0.0)


### PR DESCRIPTION
Indicates kernel already provides `wireguard.ko` so `wireguard-dkms` is unnecessary when installing `wireguard` package.

See [Discourse thread](https://discourse.osmc.tv/t/91569) for context.