### PR TITLE
[package] [kernel-osmc] Fix wireguard-modules architecture

### DIFF
--- a/package/kernel-osmc/build.sh
+++ b/package/kernel-osmc/build.sh
@@ -65,6 +65,7 @@ then
 	make clean
 	sed '/Package/d' -i files/DEBIAN/control
 	sed '/Depends/d' -i files/DEBIAN/control
+	sed '/Provides/d' -i files/DEBIAN/control
 	sed '/Package/d' -i files-image/DEBIAN/control
 	sed '/Version/d' -i files-image/DEBIAN/control
         sed '/Package/d' -i files-headers/DEBIAN/control
@@ -367,6 +368,14 @@ EOF
 	else
 		echo "Depends: ${1}-image-${VERSION}-${REV}-osmc" >> files/DEBIAN/control
 	fi
+	case "$1" in
+		rbp464|vero364)
+			echo "Provides: wireguard-modules:armhf (= 2.0.0)" >> files/DEBIAN/control
+			;;
+		*)
+			echo "Provides: wireguard-modules (= 2.0.0)" >> files/DEBIAN/control
+			;;
+	esac
 	fix_arch_ctl "files/DEBIAN/control"
 	dpkg_build files/ ${1}-kernel-${VERSION}-${REV}-osmc.deb
 	build_return=$?

--- a/package/kernel-osmc/files/DEBIAN/control
+++ b/package/kernel-osmc/files/DEBIAN/control
@@ -5,4 +5,3 @@ Essential: No
 Priority: required
 Maintainer: Sam G Nazarko <email@samnazarko.co.uk>
 Description: Kernel meta package bringing in the latest OSMC kernel for this device
-Provides: wireguard-modules (= 2.0.0)


### PR DESCRIPTION
This is a correction to https://github.com/osmc/osmc/pull/671, which didn't take the kernel package architecture into account.

On platforms where the kernel and user space architectures differ, the kernel must provide "wireguard-modules" in the user space architecture to satisfy the "wireguard" package dependency.