### PR TITLE
Change Installer for OSX to pkg rather than dmg, so the installer can write to SD CARD/USB

### DIFF
--- a/installer/host/Scripts/postinstall
+++ b/installer/host/Scripts/postinstall
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+osascript -e 'do shell script "sudo bash -c /Applications/osmc-installer.app/Contents/MacOS/qt_host_installer"'
+
+exit 0

--- a/installer/host/make_host_osx.sh
+++ b/installer/host/make_host_osx.sh
@@ -42,8 +42,6 @@ sed -e s/VERVAL/${VERSION}/ -i old ${TARGET}.app/Contents/Info.plist
 # Update on server
 echo Packaging installer
 popd
-echo Packaging installer
-
 pkgbuild --identifier 1 \
          --version 28.1 \
          --root qt_host_installer/qt_host_installer.app \

--- a/installer/host/make_host_osx.sh
+++ b/installer/host/make_host_osx.sh
@@ -42,6 +42,7 @@ sed -e s/VERVAL/${VERSION}/ -i old ${TARGET}.app/Contents/Info.plist
 # Update on server
 echo Packaging installer
 popd
+echo ${VERSION} > latest_mac
 pkgbuild --identifier 1 \
          --version 28.1 \
          --root qt_host_installer/qt_host_installer.app \

--- a/installer/host/make_host_osx.sh
+++ b/installer/host/make_host_osx.sh
@@ -41,8 +41,10 @@ VERSION=$(cat ${TARGET}.pro | grep VERSION | tail -n 1 | awk {'print $3'})
 sed -e s/VERVAL/${VERSION}/ -i old ${TARGET}.app/Contents/Info.plist
 # Update on server
 echo Packaging installer
-macdeployqt ${TARGET}.app -dmg
 popd
-echo ${VERSION} > latest_mac
-mv ${TARGET}/${TARGET}.dmg osmc-installer.dmg
+pkgbuild --identifier 1 \
+         --version 28.1 \
+         --root qt_host_installer/qt_host_installer.app \
+         --scripts Scripts/ \
+         --install-location /Applications/osmc-installer.app osmc-installer.pkg
 echo Build complete

--- a/installer/host/make_host_osx.sh
+++ b/installer/host/make_host_osx.sh
@@ -42,6 +42,8 @@ sed -e s/VERVAL/${VERSION}/ -i old ${TARGET}.app/Contents/Info.plist
 # Update on server
 echo Packaging installer
 popd
+echo Packaging installer
+
 pkgbuild --identifier 1 \
          --version 28.1 \
          --root qt_host_installer/qt_host_installer.app \

--- a/installer/host/qt_host_installer/io_osx.cpp
+++ b/installer/host/qt_host_installer/io_osx.cpp
@@ -95,7 +95,9 @@ namespace io
    {
        devicePath.replace(" ", "\\ ");
        deviceImage.replace(" ", "\\ ");
-       QString aScript ="do shell script \"dd if="+ deviceImage + " of="+ devicePath +" bs=1m conv=sync && sync\" with administrator privileges";
+       QString aScript =(
+		"do shell script \"echo Escalation\" with administrator privileges\n"
+                "do shell script \"dd if="+ deviceImage + " of="+ devicePath +" bs=1m conv=sync && sync\"");
 
        QString osascript = "/usr/bin/osascript";
        QStringList processArguments;


### PR DESCRIPTION
No Terminal Prompt, sudo elevation is taken care of by the pkg installer. 

OSMC installer is run as a post script with sudo, so the pkg installer will need to run every time an image needs to be written. 

Also users can only change the install path, if they are prepared to run the installer from the teminal with 'sudo bash -c ./qt_host_installer' (Which they can also do, if they don't want to run the installer again). 

Someone with C/C++ (better) knowledge, would be able to come up with a better solution. Just depends if it warrants more time being as the installer is at some point being re-written?

Regards Tom. 