### PR TITLE
[package][mediacenter-addon-osmc] Fix BT pairing for Python 3

### DIFF
--- a/package/mediacenter-addon-osmc/src/script.module.osmcsetting.networking/resources/language/resource.language.en_gb/strings.po
+++ b/package/mediacenter-addon-osmc/src/script.module.osmcsetting.networking/resources/language/resource.language.en_gb/strings.po
@@ -233,7 +233,7 @@ msgid "No"
 msgstr ""
 
 msgctxt "#32056"
-msgid "Pair with PIN"
+msgid "Pair and connect"
 msgstr ""
 
 msgctxt "#32057"

--- a/package/mediacenter-addon-osmc/src/script.module.osmcsetting.networking/resources/lib/osmcnetworking/networking_gui.py
+++ b/package/mediacenter-addon-osmc/src/script.module.osmcsetting.networking/resources/lib/osmcnetworking/networking_gui.py
@@ -1533,9 +1533,9 @@ class NetworkingGui(xbmcgui.WindowXMLDialog):
                 alias = item.getProperty('alias')
 
                 #              'Connect With Device'
-                #              'No'        'Pair and Connect' 'pair'
+                #              'No'        'Pair and Connect'
                 selection = DIALOG.select(self.lang(32022) + ' ' + alias + '?',
-                                          [self.lang(32055), self.lang(32056), self.lang(32057)])
+                                          [self.lang(32055), self.lang(32056)])
 
                 if selection == -1 or selection == 0:
                     return

--- a/package/mediacenter-addon-osmc/src/script.module.osmcsetting.networking/resources/lib/osmcnetworking/osmc_bluetooth.py
+++ b/package/mediacenter-addon-osmc/src/script.module.osmcsetting.networking/resources/lib/osmcnetworking/osmc_bluetooth.py
@@ -230,7 +230,7 @@ class OSMCBluetooth:
 
         paired = False
         print('calling agent "' + script + '"')
-        child = pexpect.spawn(script)
+        child = pexpect.spawn(script, encoding='utf-8')
 
         while True:
             try:
@@ -239,8 +239,8 @@ class OSMCBluetooth:
                 if len(split[0]) > 0:
                     log('Output From Pairing Agent ' + split[0])
                 d = json.loads(split[1])
-                return_value = d.keys()[0]
-                messages = d.values()[0]
+                return_value = list(d.keys())[0]
+                messages = list(d.values())[0]
                 log(['return_value = ' + return_value, 'Messages = ' + str(messages)])
                 if return_value == 'PAIRING_OK':
                     paired = True

--- a/package/mediacenter-addon-osmc/src/script.module.osmcsetting.networking/resources/lib/osmcnetworking/osmc_bluetooth_agent.py
+++ b/package/mediacenter-addon-osmc/src/script.module.osmcsetting.networking/resources/lib/osmcnetworking/osmc_bluetooth_agent.py
@@ -16,12 +16,9 @@ import dbus
 import dbus.mainloop.glib
 import dbus.service
 
-from . import bluezutils
+import bluezutils
 
-try:
-    from gi.repository import GObject
-except ImportError:
-    import gobject as GObject
+from gi.repository import GLib
 
 PEXPECT_SOL = 'SOL@'
 PEXPECT_EOL = '@EOL'
@@ -47,8 +44,8 @@ def decode_response(message):
         json_str = message.replace(PEXPECT_SOL, '').replace(PEXPECT_EOL, '')
 
         return_value = json.loads(json_str)
-        if return_value.keys()[0] == 'RETURN_VALUE':
-            return str(return_value.values()[0][0])
+        if list(return_value.keys())[0] == 'RETURN_VALUE':
+            return str(list(return_value.values())[0][0])
 
         return None
 
@@ -149,7 +146,7 @@ class Agent(dbus.service.Object):
         return_status('YESNO_INPUT', message_list)
         return_str = input('AUTHORIZE Device:')
         return_value = decode_response(return_str)
-        if return_value.keys()[0] == 'RETURN_VALUE':
+        if list(return_value.keys())[0] == 'RETURN_VALUE':
             if return_value == 'YES':
                 return
             raise Rejected("Passkey doesn't match")
@@ -196,7 +193,7 @@ if __name__ == '__main__':
     (options, args) = parser.parse_args()
 
     agent = Agent(bus, AGENT_PATH)
-    mainloop = GObject.MainLoop()
+    mainloop = GLib.MainLoop()
     obj = bus.get_object(BUS_NAME, "/org/bluez")
     manager = dbus.Interface(obj, "org.bluez.AgentManager1")
     manager.RegisterAgent(AGENT_PATH, options.capability)


### PR DESCRIPTION
Syntax changes to work with python 3
Remove deprecated GObject use
Removed Connect without PIN - bluez should automatically choose
pairing method according to device capabilities (BT version support)