### PR TITLE
Fix 'sudo-askpass.osascript.js: No such file or directory'

### DIFF
--- a/installer/host/qt_host_installer/io_osx.cpp
+++ b/installer/host/qt_host_installer/io_osx.cpp
@@ -95,7 +95,7 @@ namespace io
    {
        devicePath.replace(" ", "\\ ");
        deviceImage.replace(" ", "\\ ");
-       QString aScript ="do shell script \"SUDO_ASKPASS=/Volumes/qt_host_installer/qt_host_installer.app/Contents/MacOS/sudo-askpass.osascript.js sudo -A  /bin/dd if="+ deviceImage + " of="+ devicePath +" bs=1m conv=sync && sync\"";
+       QString aScript ="do shell script \"SUDO_ASKPASS=../MacOS/sudo-askpass.osascript.js sudo -A  /bin/dd if="+ deviceImage + " of="+ devicePath +" bs=1m conv=sync && sync\"";
 
        QString osascript = "/usr/bin/osascript";
        QStringList processArguments;

--- a/installer/host/qt_host_installer/main.cpp
+++ b/installer/host/qt_host_installer/main.cpp
@@ -6,6 +6,11 @@
 #include "mainwindow.h"
 #include "utils.h"
 #include <QFontDatabase>
+#include <QFontDatabase>
+    #ifdef __APPLE__
+    #include <iostream>
+    #include "CoreFoundation/CoreFoundation.h"
+    #endif
 
 int main(int argc, char *argv[])
 {
@@ -25,6 +30,19 @@ int main(int argc, char *argv[])
     w.show();
     #ifdef Q_OS_MAC
     w.raise();
+    #endif
+    #ifdef __APPLE__
+        CFBundleRef mainBundle = CFBundleGetMainBundle();
+        CFURLRef resourcesURL = CFBundleCopyResourcesDirectoryURL(mainBundle);
+        char path[PATH_MAX];
+        if (!CFURLGetFileSystemRepresentation(resourcesURL, TRUE, (UInt8 *)path, PATH_MAX))
+        {
+            // error!
+        }
+        CFRelease(resourcesURL);
+
+        chdir(path);
+        std::cout << "Current Path: " << path << std::endl;
     #endif
     w.activateWindow();
     return a.exec();


### PR DESCRIPTION
Script now uses retaliative path instead of absolute. When the installer is run the working directory is changed to the resources folder. Change on affects apple/osx.  