### PR TITLE
Remove surround40 from ALSA pcm blacklist

### DIFF
--- a/package/mediacenter-osmc/patches/all-133-remove-surround40-from-ALSA-pcm-blacklist.patch
+++ b/package/mediacenter-osmc/patches/all-133-remove-surround40-from-ALSA-pcm-blacklist.patch
@@ -1,0 +1,50 @@
+From 9f960aee1ca5dfbebac18c9e69dbacd01d67fb28 Mon Sep 17 00:00:00 2001
+From: Ryan Underwood <nemesis@icequake.net>
+Date: Sat, 13 May 2023 18:03:41 -0500
+Subject: [PATCH] Remove surround40 from ALSA pcm blacklist
+
+Signed-off-by: Ryan Underwood <nemesis@icequake.net>
+---
+ xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp | 9 +++++++--
+ 1 file changed, 7 insertions(+), 2 deletions(-)
+
+diff --git a/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp b/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
+index 86a3d359ee..e8ed0ac737 100644
+--- a/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
++++ b/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
+@@ -1189,7 +1189,6 @@ void CAESinkALSA::EnumerateDevicesEx(AEDeviceInfoList &list, bool force)
+        * "plughw", "dsnoop"). */
+ 
+       else if (baseName != "default"
+-            && baseName != "surround40"
+             && baseName != "surround41"
+             && baseName != "surround50"
+             && baseName != "surround51"
+@@ -1261,6 +1260,8 @@ void CAESinkALSA::EnumerateDevicesEx(AEDeviceInfoList &list, bool force)
+ 
+   for (AEDeviceInfoList::iterator it1 = list.begin(); it1 != list.end(); ++it1)
+   {
++    std::string replacementName = "";
++
+     for (AEDeviceInfoList::iterator it2 = it1+1; it2 != list.end(); ++it2)
+     {
+       if (it1->m_displayName == it2->m_displayName
+@@ -1290,10 +1291,14 @@ void CAESinkALSA::EnumerateDevicesEx(AEDeviceInfoList &list, bool force)
+         }
+ 
+         /* if we got here, the configuration is really weird, just append the whole device string */
+-        it1->m_displayName += " (" + it1->m_deviceName + ")";
++        replacementName = it1->m_displayName + " (" + it1->m_deviceName + ")";
+         it2->m_displayName += " (" + it2->m_deviceName + ")";
+       }
+     }
++
++    if (!replacementName.empty()) {
++      it1->m_displayName = replacementName;
++    }
+   }
+ 
+   for (std::set<std::string>::iterator it = cardsToAppend.begin();
+-- 
+2.39.2
+


### PR DESCRIPTION
There is a real-world need to be able to force downmixing to 4.0 even if Kodi is configured for more channels and more channels are available.

For instance, a Klipsch ProMedia v.2-400 system has 4 speakers and a subwoofer, but the subwoofer is addressed with an internal crossover rather than a dedicated LFE connection.  It is connected via a C-Media 7.1 USB sound card which has 4 pairs of analog outputs, so the surroundXX detection performed on the '@' device falls through to 8 channels and sound is then output to center/LFE and rear speaker jacks instead of downmixed.  Those jacks are impossible to connect to the Klipsch system since it only has 2 inputs: front stereo and rear (surround) stereo 3.5mm.

Other late 1990s and early 2000s PC speaker systems designed for use with sound cards supporting positional audio will be similar.  These sound cards typically only had front and rear analog 3.5mm jacks and no center/LFE jack, so the speaker systems have two 3.5mm jacks for inputs and use a crossover to isolate LFE.

It's additionally required to set the "Include LFE in stereo(?) downmix" to a nonzero value so that LFE is included in the downmix.  Since systems like this Klipsch system have an internal crossover, 100% is the correct value.