### PR TITLE
Update osmc_backups.py

### DIFF
--- a/package/mediacenter-addon-osmc/src/script.module.osmcsetting.updates/resources/lib/osmcupdates/osmc_backups.py
+++ b/package/mediacenter-addon-osmc/src/script.module.osmcsetting.updates/resources/lib/osmcupdates/osmc_backups.py
@@ -502,7 +502,7 @@ class OSMCBackup(object):
                 success = os.path.isfile(remote_tarball_name)
 
             if not success:
-                log('The third attempt to copy the backup tarball to the remote address was unsuccessfull, giving up')
+                log('The third attempt to copy the backup tarball to the remote address was unsuccessful, giving up')
 
             if success:
                 log('Finally, backup file successfully transferred')

--- a/package/mediacenter-addon-osmc/src/script.module.osmcsetting.updates/resources/lib/osmcupdates/osmc_backups.py
+++ b/package/mediacenter-addon-osmc/src/script.module.osmcsetting.updates/resources/lib/osmcupdates/osmc_backups.py
@@ -488,13 +488,24 @@ class OSMCBackup(object):
             log('remote tarball exists: %s' % os.path.isfile(remote_tarball_name))
 
             success = xbmcvfs.copy(local_tarball_name, remote_tarball_name)
+
+            # second try in case of timeout using a hibernated NAS or disk, wait a minute for the awakening
             if not success:
+                log('First attempt to copy backup file to remote address was unsuccessfull, trying again')
+                xbmc.sleep(60000)
+                success = xbmcvfs.copy(local_tarball_name, remote_tarball_name)
+
+            if not success:
+                log('Second attempt to copy backup file to remote address was unsuccessfull, trying simple cp method')
                 subprocess.Popen(['cp', local_tarball_name, remote_tarball_name])
                 xbmc.sleep(300)
                 success = os.path.isfile(remote_tarball_name)
 
+            if not success:
+                log('Third attempt to copy backup file to remote address was unsuccessfull, giving up')
+
             if success:
-                log('Backup file successfully transferred')
+                log('Finally, backup file successfully transferred')
                 try:
                     xbmcvfs.delete(local_tarball_name)
                 except:

--- a/package/mediacenter-addon-osmc/src/script.module.osmcsetting.updates/resources/lib/osmcupdates/osmc_backups.py
+++ b/package/mediacenter-addon-osmc/src/script.module.osmcsetting.updates/resources/lib/osmcupdates/osmc_backups.py
@@ -491,18 +491,18 @@ class OSMCBackup(object):
 
             # second try in case of timeout using a hibernated NAS or disk, wait a minute for the awakening
             if not success:
-                log('First attempt to copy backup file to remote address was unsuccessfull, trying again')
+                log('The first attempt to copy the backup tarball to the remote address was unsuccessful, will try again')
                 xbmc.sleep(60000)
                 success = xbmcvfs.copy(local_tarball_name, remote_tarball_name)
 
             if not success:
-                log('Second attempt to copy backup file to remote address was unsuccessfull, trying simple cp method')
+                log('The second attempt to copy the backup tarball to the remote address was unsuccessful, trying the simple cp method')
                 subprocess.Popen(['cp', local_tarball_name, remote_tarball_name])
                 xbmc.sleep(300)
                 success = os.path.isfile(remote_tarball_name)
 
             if not success:
-                log('Third attempt to copy backup file to remote address was unsuccessfull, giving up')
+                log('The third attempt to copy the backup tarball to the remote address was unsuccessfull, giving up')
 
             if success:
                 log('Finally, backup file successfully transferred')


### PR DESCRIPTION
Copying the osmc backup tarball to a remote address on a hibernated NAS can fail/timeout using the  xbmcvfs.copy method. Implementing a second try after 60 seconds wait for the awakening.