### PR TITLE
Update grablogs.py

### DIFF
--- a/package/mediacenter-addon-osmc/src/script.module.osmccommon/resources/lib/osmccommon/grablogs.py
+++ b/package/mediacenter-addon-osmc/src/script.module.osmccommon/resources/lib/osmccommon/grablogs.py
@@ -323,7 +323,7 @@ SETS = {
                 'name': 'System Journal',
                 'key': 'MyqVXi2x',
                 'ltyp': 'cl_log',
-                'actn': 'sudo journalctl -n 30000 --since "1 days ago"',
+                'actn': '/bin/bash -c "sudo journalctl --flush && sudo journalctl -n 30000 --since -24h"',
             },
         ],
     },


### PR DESCRIPTION
This is to prevent incomplete system journal logging. A previous call to 'journalctl --flush' should flush all data from /run/log/journal to /var/log/journal.