### PR TITLE
[package][mediacenter-addon-osmc] grablogs - change to cta_cap

### DIFF
--- a/package/mediacenter-addon-osmc/src/script.module.osmccommon/resources/lib/osmccommon/grablogs.py
+++ b/package/mediacenter-addon-osmc/src/script.module.osmccommon/resources/lib/osmccommon/grablogs.py
@@ -459,7 +459,7 @@ SETS = {
                 'name': 'Display Cap CTA',
                 'key': 'g0gjk991',
                 'ltyp': 'file_log',
-                'actn': '/sys/class/amhdmitx/amhdmitx0/disp_cap',
+                'actn': '/sys/class/amhdmitx/amhdmitx0/cta_cap',
                 'hwid': '!rbp',
             },
             {


### PR DESCRIPTION
cta_cap prints only CTA modes as implied by the section heading