### PR TITLE
[package] [aml-vnc-app-osmc] Fix missing arch-specific json issue

### DIFF
--- a/package/aml-vnc-app-osmc/build.sh
+++ b/package/aml-vnc-app-osmc/build.sh
@@ -30,6 +30,7 @@ then
 	strip_files "${out}"
 	popd
 	fix_arch_ctl "files/DEBIAN/control"
+	publish_applications_targeted "$(pwd)" "$1" "aml-vnc-app-osmc"
 	dpkg_build files/ ${1}-aml-vnc-app-osmc.deb
 	build_return=$?
 fi


### PR DESCRIPTION
The App Store gives an error during installation, this is probably because of this missing line in the `build.sh`.