### PR TITLE
[package] [aml-vnc-app-osmc] Fix service crash on first connection after boot

### DIFF
--- a/package/aml-vnc-app-osmc/app.json
+++ b/package/aml-vnc-app-osmc/app.json
@@ -6,8 +6,8 @@
             "shortdesc": "A simple VNC server for OSMC Vero",
             "longdesc": "This package installs a VNC server on your device which can be accessed via VNC client. The default password is osmc.",
             "maintained-by": "OSMC",
-            "version": "1.0.0-1",
-            "lastupdated": "2023-12-05",
+            "version": "1.0.0-2",
+            "lastupdated": "2023-12-11",
             "iconurl": "NA",
             "iconhash": "NA"
         }

--- a/package/aml-vnc-app-osmc/build.sh
+++ b/package/aml-vnc-app-osmc/build.sh
@@ -4,7 +4,7 @@
 #!/bin/bash
 
 . ../common.sh
-VERSION="df9c6501f95a5f5578546fe09c361e0982288e4f"
+VERSION="1.0.0"
 pull_source "https://github.com/osmc/aml-vnc-server/archive/${VERSION}.tar.gz" "$(pwd)/src"
 if [ $? != 0 ]; then echo -e "Error downloading" && exit 1; fi
 # Build in native environment
@@ -15,7 +15,7 @@ then
 	echo -e "Building VNC Server for Vero"
 	out=$(pwd)/files
 	sed '/Package/d' -i files/DEBIAN/control
-	echo "Package: ${1}-aml-vnc-app-osmc" >> files/DEBIAN/control
+	rm -f files/etc/osmc/apps.d/*aml-vnc-app-osmc
 	update_sources
 	handle_dep libvncserver-dev
 	handle_dep libpng-dev

--- a/package/aml-vnc-app-osmc/files/DEBIAN/control
+++ b/package/aml-vnc-app-osmc/files/DEBIAN/control
@@ -1,6 +1,6 @@
 Origin: OSMC
 Package: aml-vnc-app-osmc
-Version: 1.0.0-1
+Version: 1.0.0-2
 Section: metapackages
 Essential: No
 Depends: libvncserver1

--- a/package/aml-vnc-app-osmc/files/lib/systemd/system/aml-vnc.service
+++ b/package/aml-vnc-app-osmc/files/lib/systemd/system/aml-vnc.service
@@ -5,10 +5,11 @@ After = network-online.target
 [Service]
 Type = simple
 EnvironmentFile = /etc/osmc/prefs.d/aml-vnc.conf
+ExecStartPre = /bin/sleep 5
 ExecStart = /usr/bin/aml-vnc
 TimeoutStopSec = 20
 Restart = always
-RestartSec = 5
+RestartSec = 0
 
 [Install]
 WantedBy = multi-user.target


### PR DESCRIPTION
The VNC server crashes on first connection after boot because it starts earlier than Kodi and starts with incorrect resolution/color scheme. Delaying the start of the service solves this issue.

In addition, a few minor build corrections, which are highlighted in review comments.