### PR TITLE
[package] [aml-vnc-app-osmc] Bump to 1.0.1-1

### DIFF
--- a/package/aml-vnc-app-osmc/app.json
+++ b/package/aml-vnc-app-osmc/app.json
@@ -6,8 +6,8 @@
             "shortdesc": "A simple VNC server for OSMC Vero",
             "longdesc": "This package installs a VNC server on your device which can be accessed via VNC client. The default password is osmc.",
             "maintained-by": "OSMC",
-            "version": "1.0.0-2",
-            "lastupdated": "2023-12-11",
+            "version": "1.0.1-1",
+            "lastupdated": "2023-12-13",
             "iconurl": "NA",
             "iconhash": "NA"
         }

--- a/package/aml-vnc-app-osmc/build.sh
+++ b/package/aml-vnc-app-osmc/build.sh
@@ -4,7 +4,7 @@
 #!/bin/bash
 
 . ../common.sh
-VERSION="1.0.0"
+VERSION="1.0.1"
 pull_source "https://github.com/osmc/aml-vnc-server/archive/${VERSION}.tar.gz" "$(pwd)/src"
 if [ $? != 0 ]; then echo -e "Error downloading" && exit 1; fi
 # Build in native environment

--- a/package/aml-vnc-app-osmc/files/DEBIAN/control
+++ b/package/aml-vnc-app-osmc/files/DEBIAN/control
@@ -1,6 +1,6 @@
 Origin: OSMC
 Package: aml-vnc-app-osmc
-Version: 1.0.0-2
+Version: 1.0.1-1
 Section: metapackages
 Essential: No
 Depends: libvncserver1


### PR DESCRIPTION
Fixed server performance issues on OSMC 2023-12 release.

**Reference:**
https://www.youtube.com/watch?v=OUXYszop0t0

**Changes:**
- fix pixel comparison between VNC image buffer and framebuffer,
- reset comparison matrix grid distance from 12x12 to 4x4, because dirty regions remain when using some Kodi skins,
- filling image buffer in every line with memcpy, instead of filling from byte to byte by a for loop.

**Here is a binary package for testing, built from the same code base:**
https://libreelec.dtech.hu/.upload/armv7-aml-vnc-app-osmc_1.0.1-0pre1_armhf.deb

**Additional steps required before merging:**
- Please add a `1.0.1` tag to this commit: https://github.com/osmc/aml-vnc-server/commit/57e041342a5ae0fc3de7573ca43d31cef033a62a.