### PR TITLE
[package] [aml-vnc-app-osmc] Bump to 1.1.0-1

### DIFF
--- a/package/aml-vnc-app-osmc/app.json
+++ b/package/aml-vnc-app-osmc/app.json
@@ -6,8 +6,8 @@
             "shortdesc": "A simple VNC server for OSMC Vero",
             "longdesc": "This package installs a VNC server on your device which can be accessed via VNC client. The default password is osmc.",
             "maintained-by": "OSMC",
-            "version": "1.0.1-1",
-            "lastupdated": "2023-12-13",
+            "version": "1.1.0-1",
+            "lastupdated": "2023-12-31",
             "iconurl": "NA",
             "iconhash": "NA"
         }

--- a/package/aml-vnc-app-osmc/build.sh
+++ b/package/aml-vnc-app-osmc/build.sh
@@ -4,7 +4,7 @@
 #!/bin/bash
 
 . ../common.sh
-VERSION="1.0.1"
+VERSION="1.1.0"
 pull_source "https://github.com/osmc/aml-vnc-server/archive/${VERSION}.tar.gz" "$(pwd)/src"
 if [ $? != 0 ]; then echo -e "Error downloading" && exit 1; fi
 # Build in native environment

--- a/package/aml-vnc-app-osmc/files/DEBIAN/control
+++ b/package/aml-vnc-app-osmc/files/DEBIAN/control
@@ -1,6 +1,6 @@
 Origin: OSMC
 Package: aml-vnc-app-osmc
-Version: 1.0.1-1
+Version: 1.1.0-1
 Section: metapackages
 Essential: No
 Depends: libvncserver1


### PR DESCRIPTION
Update package source to AML-VNC Server v1.1.0.

**Additional steps required before merging:**
- Please merge this PR in the source repository:
https://github.com/osmc/aml-vnc-server/pull/2
- Please also add a `1.1.0` tag to the last commit after the merge.