### PR TITLE
[package] [mediacenter-addon-osmc] add hotfix retrieval from osmc mirrors

### DIFF
--- a/package/mediacenter-addon-osmc/src/script.module.osmcsetting.updates/resources/lib/osmcupdates/osmc_hotfix.py
+++ b/package/mediacenter-addon-osmc/src/script.module.osmcsetting.updates/resources/lib/osmcupdates/osmc_hotfix.py
@@ -191,7 +191,8 @@ class HotFix(object):
                             break
                     continue
 
-            instruction.append(line.replace('INSTRUCTION:', '').strip())
+            if line:
+                instruction.append(line.replace('INSTRUCTION:', '').strip())
 
         log(label='Description', message=description)
         log(label='Instruction', message=instruction)


### PR DESCRIPTION
- attempt to find and download hotfixes from https://ftp.fau.de/osmc/osmc/download/hotfixes/ first
- if hotfix available from https://ftp.fau.de/osmc/osmc/download/hotfixes/ remove "Only use Hotfixes provided by people you trust." from confirmation dialog