### PR TITLE
Fix ssh deprecations

### DIFF
--- a/package/ssh-app-osmc/files/etc/ssh/sshd_config
+++ b/package/ssh-app-osmc/files/etc/ssh/sshd_config
@@ -11,8 +11,6 @@ Protocol 2
 HostKey /etc/ssh/ssh_host_rsa_key
 HostKey /etc/ssh/ssh_host_ecdsa_key
 HostKey /etc/ssh/ssh_host_ed25519_key
-#Privilege Separation is turned on for security
-UsePrivilegeSeparation sandbox
 
 # Lifetime and size of ephemeral version 1 server key
 KeyRegenerationInterval 3600

--- a/package/ssh-app-osmc/files/etc/ssh/sshd_config
+++ b/package/ssh-app-osmc/files/etc/ssh/sshd_config
@@ -12,10 +12,6 @@ HostKey /etc/ssh/ssh_host_rsa_key
 HostKey /etc/ssh/ssh_host_ecdsa_key
 HostKey /etc/ssh/ssh_host_ed25519_key
 
-# Lifetime and size of ephemeral version 1 server key
-KeyRegenerationInterval 3600
-ServerKeyBits 1024
-
 # Logging
 SyslogFacility AUTH
 LogLevel INFO
@@ -25,7 +21,6 @@ LoginGraceTime 120
 PermitRootLogin yes
 StrictModes yes
 
-RSAAuthentication yes
 PubkeyAuthentication yes
 #AuthorizedKeysFile	%h/.ssh/authorized_keys
 
@@ -36,8 +31,6 @@ MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@op
 
 # Don't read the user's ~/.rhosts and ~/.shosts files
 IgnoreRhosts yes
-# For this to work you will also need host keys in /etc/ssh_known_hosts
-RhostsRSAAuthentication no
 # similar for protocol version 2
 HostbasedAuthentication no
 # Uncomment if you don't trust ~/.ssh/known_hosts for RhostsRSAAuthentication


### PR DESCRIPTION
There are messages about deprecated `sshd_config` settings in the log:
```
Feb 17 17:07:33 showmaster sshd[21022]: rexec line 15: Deprecated option UsePrivilegeSeparation
Feb 17 17:07:33 showmaster sshd[21022]: rexec line 18: Deprecated option KeyRegenerationInterval
Feb 17 17:07:33 showmaster sshd[21022]: rexec line 19: Deprecated option ServerKeyBits
Feb 17 17:07:33 showmaster sshd[21022]: rexec line 30: Deprecated option RSAAuthentication
Feb 17 17:07:33 showmaster sshd[21022]: rexec line 42: Deprecated option RhostsRSAAuthentication
Feb 17 17:07:33 showmaster sshd[21022]: reprocess config line 30: Deprecated option RSAAuthentication
Feb 17 17:07:33 showmaster sshd[21022]: reprocess config line 42: Deprecated option RhostsRSAAuthentication
```

This change fixes them