### PR TITLE
Comment options with default

### DIFF
--- a/package/ssh-app-osmc/files/etc/ssh/sshd_config
+++ b/package/ssh-app-osmc/files/etc/ssh/sshd_config
@@ -11,8 +11,6 @@ Protocol 2
 HostKey /etc/ssh/ssh_host_rsa_key
 HostKey /etc/ssh/ssh_host_ecdsa_key
 HostKey /etc/ssh/ssh_host_ed25519_key
-#Privilege Separation is turned on for security
-UsePrivilegeSeparation sandbox
 
 # Lifetime and size of ephemeral version 1 server key
 KeyRegenerationInterval 3600

--- a/package/ssh-app-osmc/files/etc/ssh/sshd_config
+++ b/package/ssh-app-osmc/files/etc/ssh/sshd_config
@@ -12,10 +12,6 @@ HostKey /etc/ssh/ssh_host_rsa_key
 HostKey /etc/ssh/ssh_host_ecdsa_key
 HostKey /etc/ssh/ssh_host_ed25519_key
 
-# Lifetime and size of ephemeral version 1 server key
-KeyRegenerationInterval 3600
-ServerKeyBits 1024
-
 # Logging
 SyslogFacility AUTH
 LogLevel INFO
@@ -25,7 +21,6 @@ LoginGraceTime 120
 PermitRootLogin yes
 StrictModes yes
 
-RSAAuthentication yes
 PubkeyAuthentication yes
 #AuthorizedKeysFile	%h/.ssh/authorized_keys
 
@@ -36,8 +31,6 @@ MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@op
 
 # Don't read the user's ~/.rhosts and ~/.shosts files
 IgnoreRhosts yes
-# For this to work you will also need host keys in /etc/ssh_known_hosts
-RhostsRSAAuthentication no
 # similar for protocol version 2
 HostbasedAuthentication no
 # Uncomment if you don't trust ~/.ssh/known_hosts for RhostsRSAAuthentication

--- a/package/ssh-app-osmc/files/etc/ssh/sshd_config
+++ b/package/ssh-app-osmc/files/etc/ssh/sshd_config
@@ -2,26 +2,25 @@
 # See the sshd_config(5) manpage for details
 
 # What ports, IPs and protocols we listen for
-Port 22
+#Port 22
 # Use these options to restrict which interfaces/protocols sshd will bind to
 #ListenAddress ::
 #ListenAddress 0.0.0.0
-Protocol 2
 # HostKeys for protocol version 2
-HostKey /etc/ssh/ssh_host_rsa_key
-HostKey /etc/ssh/ssh_host_ecdsa_key
-HostKey /etc/ssh/ssh_host_ed25519_key
+#HostKey /etc/ssh/ssh_host_rsa_key
+#HostKey /etc/ssh/ssh_host_ecdsa_key
+#HostKey /etc/ssh/ssh_host_ed25519_key
 
 # Logging
-SyslogFacility AUTH
-LogLevel INFO
+#SyslogFacility AUTH
+#LogLevel INFO
 
 # Authentication:
-LoginGraceTime 120
+#LoginGraceTime 120
 PermitRootLogin yes
-StrictModes yes
+#StrictModes yes
 
-PubkeyAuthentication yes
+#PubkeyAuthentication yes
 #AuthorizedKeysFile	%h/.ssh/authorized_keys
 
 #Use safest ciphers and algorithms in priority
@@ -30,14 +29,14 @@ Ciphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.
 MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,umac-128@openssh.com
 
 # Don't read the user's ~/.rhosts and ~/.shosts files
-IgnoreRhosts yes
+#IgnoreRhosts yes
 # similar for protocol version 2
-HostbasedAuthentication no
+#HostbasedAuthentication no
 # Uncomment if you don't trust ~/.ssh/known_hosts for RhostsRSAAuthentication
 #IgnoreUserKnownHosts yes
 
 # To enable empty passwords, change to yes (NOT RECOMMENDED)
-PermitEmptyPasswords no
+#PermitEmptyPasswords no
 
 # Change to yes to enable challenge-response passwords (beware issues with
 # some PAM modules and threads)
@@ -56,11 +55,11 @@ ChallengeResponseAuthentication no
 #GSSAPIAuthentication no
 #GSSAPICleanupCredentials yes
 
-X11Forwarding no
-X11DisplayOffset 10
+#X11Forwarding no
+#X11DisplayOffset 10
 PrintMotd no
-PrintLastLog yes
-TCPKeepAlive yes
+#PrintLastLog yes
+#TCPKeepAlive yes
 #UseLogin no
 
 #MaxStartups 10:30:60


### PR DESCRIPTION
The fewer deviations from standard (debian) values there are, the fewer things one will have to take care of on updates.
The defaults from both OpenSSH and Debian are usually a sane choice, so I comment everything that uses the default value anyway.