### PR TITLE
[package] [aml-vnc-app-osmc] Bump to 1.2.1-1

### DIFF
--- a/package/aml-vnc-app-osmc/app.json
+++ b/package/aml-vnc-app-osmc/app.json
@@ -6,8 +6,8 @@
             "shortdesc": "A simple VNC server for OSMC Vero",
             "longdesc": "This package installs a VNC server on your device which can be accessed via VNC client. The default password is osmc.",
             "maintained-by": "OSMC",
-            "version": "1.2.0-1",
-            "lastupdated": "2024-02-09",
+            "version": "1.2.1-1",
+            "lastupdated": "2025-03-02",
             "iconurl": "NA",
             "iconhash": "NA"
         }

--- a/package/aml-vnc-app-osmc/build.sh
+++ b/package/aml-vnc-app-osmc/build.sh
@@ -4,7 +4,7 @@
 #!/bin/bash
 
 . ../common.sh
-VERSION="1.2.0"
+VERSION="1.2.1"
 pull_source "https://github.com/osmc/aml-vnc-server/archive/${VERSION}.tar.gz" "$(pwd)/src"
 if [ $? != 0 ]; then echo -e "Error downloading" && exit 1; fi
 # Build in native environment

--- a/package/aml-vnc-app-osmc/files/DEBIAN/control
+++ b/package/aml-vnc-app-osmc/files/DEBIAN/control
@@ -1,6 +1,6 @@
 Origin: OSMC
 Package: aml-vnc-app-osmc
-Version: 1.2.0-1
+Version: 1.2.1-1
 Section: metapackages
 Essential: No
 Depends: libvncserver1


### PR DESCRIPTION
Update package source to AML-VNC Server v1.2.1.

**Additional steps required before merging:**
- Please merge this PR in the source repository:
https://github.com/osmc/aml-vnc-server/pull/4
- Please also add a `1.2.1` tag to the last commit after the merge.