### PR TITLE
[package] [aml-vnc-app-osmc] Bump to 1.4.0-1

### DIFF
--- a/package/aml-vnc-app-osmc/app.json
+++ b/package/aml-vnc-app-osmc/app.json
@@ -6,8 +6,8 @@
             "shortdesc": "A simple VNC server for OSMC Vero",
             "longdesc": "This package installs a VNC server on your device which can be accessed via VNC client. The default password is osmc.",
             "maintained-by": "OSMC",
-            "version": "1.3.0-1",
-            "lastupdated": "2026-02-20",
+            "version": "1.4.0-1",
+            "lastupdated": "2026-06-30",
             "iconurl": "NA",
             "iconhash": "NA"
         }

--- a/package/aml-vnc-app-osmc/build.sh
+++ b/package/aml-vnc-app-osmc/build.sh
@@ -4,7 +4,7 @@
 #!/bin/bash
 
 . ../common.sh
-VERSION="1.3.0"
+VERSION="1.4.0"
 pull_source "https://github.com/osmc/aml-vnc-server/archive/${VERSION}.tar.gz" "$(pwd)/src"
 if [ $? != 0 ]; then echo -e "Error downloading" && exit 1; fi
 # Build in native environment

--- a/package/aml-vnc-app-osmc/files/DEBIAN/control
+++ b/package/aml-vnc-app-osmc/files/DEBIAN/control
@@ -1,6 +1,6 @@
 Origin: OSMC
 Package: aml-vnc-app-osmc
-Version: 1.3.0-1
+Version: 1.4.0-1
 Section: metapackages
 Essential: No
 Depends: libvncserver1

--- a/package/aml-vnc-app-osmc/files/DEBIAN/postinst
+++ b/package/aml-vnc-app-osmc/files/DEBIAN/postinst
@@ -2,6 +2,14 @@
 
 if [ "$1" = "configure" ]; then
 
+	if ! grep -q 'VNC_NOMOUSE' /etc/osmc/prefs.d/aml-vnc.conf; then
+		printf '\n# Disable sending mouse actions (Server default: mouse enabled)\n#VNC_NOMOUSE="true"\n' >> /etc/osmc/prefs.d/aml-vnc.conf
+	fi
+
+	if ! grep -q 'VNC_DEBUGLOG' /etc/osmc/prefs.d/aml-vnc.conf; then
+		printf '\n# Enable debug log from libvncserver (Server default: log disabled)\n#VNC_DEBUGLOG="true"\n' >> /etc/osmc/prefs.d/aml-vnc.conf
+	fi
+
 	systemctl daemon-reload
 	if [ -e "/var/run/${DPKG_MAINTSCRIPT_PACKAGE}_install" ]; then
 		rm -f "/var/run/${DPKG_MAINTSCRIPT_PACKAGE}_install"


### PR DESCRIPTION
Update package source to AML-VNC Server v1.4.0.

**Additional steps required before merging:**
- Please merge this PR in the source repository:
https://github.com/osmc/aml-vnc-server/pull/6
- Please also add a `1.4.0` tag to the last commit after the merge.